### PR TITLE
Fix use-storybook-testing-library default export handling

### DIFF
--- a/lib/rules/use-storybook-testing-library.js
+++ b/lib/rules/use-storybook-testing-library.js
@@ -5,6 +5,7 @@
 'use strict'
 
 const { docsUrl } = require('../utils')
+const { isImportDefaultSpecifier } = require('../utils/ast')
 const { CATEGORY_ID } = require('../utils/constants')
 
 //------------------------------------------------------------------------------
@@ -36,14 +37,48 @@ module.exports = {
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------
-    const getRangeWithoutQuotes = (node) => {
+    const getRangeWithoutQuotes = (source) => {
       return [
         // Not sure how to improve this. If I use node.source.range
         // it will eat the quotes and we do not want to specify whether the quotes are single or double
-        node.source.range[0] + 1,
-        node.source.range[1] - 1,
+        source.range[0] + 1,
+        source.range[1] - 1,
       ]
     }
+
+    const hasDefaultImport = (specifiers) => specifiers.find((s) => isImportDefaultSpecifier(s))
+
+    const getSpecifiers = (node) => {
+      const { specifiers } = node
+
+      const start = specifiers[0].range[0]
+      let end = specifiers[specifiers.length - 1].range[1]
+
+      // this weird hack is necessary because the specifier range
+      // does not include the closing brace:
+      //
+      // import foo, { bar } from 'baz';
+      //        ^        ^ end
+      const fullText = context.getSourceCode().text
+      const importEnd = node.range[1]
+      const closingBrace = fullText.indexOf('}', end - 1)
+      if (closingBrace > -1 && closingBrace <= importEnd) {
+        end = closingBrace + 1
+      }
+      const text = fullText.substring(start, end)
+
+      return { range: [start, end], text }
+    }
+
+    const fixSpecifiers = (specifiersText) => {
+      const flattened = specifiersText
+        .replace('{', '')
+        .replace('}', '')
+        .replace(/\s\s+/g, ' ')
+        .trim()
+      return `{ ${flattened} }`
+    }
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
@@ -57,20 +92,28 @@ module.exports = {
             data: {
               library: node.source.value,
             },
-            fix: function (fixer) {
-              return fixer.replaceTextRange(
-                getRangeWithoutQuotes(node),
+            *fix(fixer) {
+              yield fixer.replaceTextRange(
+                getRangeWithoutQuotes(node.source),
                 '@storybook/testing-library'
               )
+              if (hasDefaultImport(node.specifiers)) {
+                const { range, text } = getSpecifiers(node)
+                yield fixer.replaceTextRange(range, fixSpecifiers(text))
+              }
             },
             suggest: [
               {
                 messageId: 'updateImports',
-                fix: function (fixer) {
-                  return fixer.replaceTextRange(
-                    getRangeWithoutQuotes(node),
+                *fix(fixer) {
+                  yield fixer.replaceTextRange(
+                    getRangeWithoutQuotes(node.source),
                     '@storybook/testing-library'
                   )
+                  if (hasDefaultImport(node.specifiers)) {
+                    const { range, text } = getSpecifiers(node)
+                    yield fixer.replaceTextRange(range, fixSpecifiers(text))
+                  }
                 },
               },
             ],

--- a/tests/lib/rules/use-storybook-testing-library.js
+++ b/tests/lib/rules/use-storybook-testing-library.js
@@ -38,5 +38,43 @@ ruleTester.run('use-storybook-testing-library', rule, {
         },
       ],
     },
+    {
+      code: "import userEvent from '@testing-library/user-event'",
+      output: "import { userEvent } from '@storybook/testing-library'",
+      errors: [
+        {
+          messageId: 'dontUseTestingLibraryDirectly',
+          data: {
+            library: '@testing-library/user-event',
+          },
+          type: 'ImportDeclaration',
+          suggestions: [
+            {
+              messageId: 'updateImports',
+              output: "import { userEvent } from '@storybook/testing-library'",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: "import userEvent, { foo, bar as Bar } from '@testing-library/user-event'",
+      output: "import { userEvent, foo, bar as Bar } from '@storybook/testing-library'",
+      errors: [
+        {
+          messageId: 'dontUseTestingLibraryDirectly',
+          data: {
+            library: '@testing-library/user-event',
+          },
+          type: 'ImportDeclaration',
+          suggestions: [
+            {
+              messageId: 'updateImports',
+              output: "import { userEvent, foo, bar as Bar } from '@storybook/testing-library'",
+            },
+          ],
+        },
+      ],
+    },
   ],
 })


### PR DESCRIPTION
Issue: #15

## What Changed

Fixed handling of

```js
import userEvent from '@testing-library/user-event';
import userEvent, { foo, bar as Bar } from '@testing-library/user-event';
```

## Checklist

Check the ones applicable to your change:

- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
