### PR TITLE
await-interactions: Fix bad expect matchers

### DIFF
--- a/lib/rules/await-interactions.ts
+++ b/lib/rules/await-interactions.ts
@@ -7,7 +7,7 @@ import type { CallExpression, Identifier, Node } from '@typescript-eslint/types/
 
 import { createStorybookRule } from '../utils/create-storybook-rule'
 import { CategoryId } from '../utils/constants'
-import { isMemberExpression, isIdentifier, isAwaitExpression } from '../utils/ast'
+import { isMemberExpression, isIdentifier, isAwaitExpression, isCallExpression } from '../utils/ast'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -41,7 +41,6 @@ export = createStorybookRule({
     // any helper functions should go here or else delete this section
 
     const FUNCTIONS_TO_BE_AWAITED = [
-      'expect',
       'waitFor',
       'waitForElementToBeRemoved',
       'wait',
@@ -66,6 +65,16 @@ export = createStorybookRule({
         isMemberExpression(expr.callee) &&
         isIdentifier(expr.callee.property) &&
         shouldAwait(expr.callee.property.name)
+      ) {
+        return expr.callee.property
+      }
+
+      if (
+        isMemberExpression(expr.callee) &&
+        isCallExpression(expr.callee.object) &&
+        isIdentifier(expr.callee.object.callee) &&
+        isIdentifier(expr.callee.property) &&
+        expr.callee.object.callee.name === 'expect'
       ) {
         return expr.callee.property
       }

--- a/tests/lib/rules/await-interactions.test.ts
+++ b/tests/lib/rules/await-interactions.test.ts
@@ -47,6 +47,7 @@ ruleTester.run('await-interactions', rule, {
         }
       }
     `,
+    'await expect(foo).toBe(bar)',
   ],
   invalid: [
     {
@@ -173,7 +174,7 @@ ruleTester.run('await-interactions', rule, {
         },
         {
           messageId: 'interactionShouldBeAwaited',
-          data: { method: 'expect' },
+          data: { method: 'toHaveBeenCalled' },
         },
       ],
     },
@@ -231,7 +232,7 @@ ruleTester.run('await-interactions', rule, {
         },
         {
           messageId: 'interactionShouldBeAwaited',
-          data: { method: 'expect' },
+          data: { method: 'toHaveBeenCalled' },
         },
       ],
     },


### PR DESCRIPTION
Issue: N/A

## What Changed

The following should be valid

```
await expect(foo).toBe(bar);
```

This required fixing the logic around awaiting expectations!

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
