### PR TITLE
default-exports: target first non-import nodes when reporting

### DIFF
--- a/lib/rules/default-exports.ts
+++ b/lib/rules/default-exports.ts
@@ -3,6 +3,7 @@
  * @author Yann Braga
  */
 import { CategoryId } from '../utils/constants'
+import { isImportDeclaration } from '../utils/ast'
 import { createStorybookRule } from '../utils/create-storybook-rule'
 
 //------------------------------------------------------------------------------
@@ -49,9 +50,9 @@ export = createStorybookRule({
       },
       'Program:exit': function (node: any) {
         if (!hasDefaultExport) {
+          const firstNonImportStatement = node.body.find((n) => !isImportDeclaration(n))
           context.report({
-            node,
-            loc: { start: { line: 0, column: 0 }, end: { line: 0, column: 0 } },
+            node: firstNonImportStatement || node.body[0] || node,
             messageId: 'shouldHaveDefaultExport',
           })
         }

--- a/tests/lib/rules/default-exports.test.ts
+++ b/tests/lib/rules/default-exports.test.ts
@@ -36,7 +36,6 @@ ruleTester.run('default-exports', rule, {
       errors: [
         {
           messageId: 'shouldHaveDefaultExport',
-          type: AST_NODE_TYPES.Program,
         },
       ],
     },


### PR DESCRIPTION
Issue: N/A

## What Changed

<!-- Insert a description below. Don't forget to run `yarn update-all` to update configuration files and their documentation! -->

The rule `default-exports` was not allowing to be disabled. By changing the target node it is now possible

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
