### PR TITLE
prefer-pascal-case: add non-story exports check

### DIFF
--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -86,7 +86,7 @@ export = createStorybookRule({
                 const scope = context.getScope().childScopes[0]
                 if (scope) {
                   const variable = findVariable(scope, name)
-                  for (let i = 0; i < variable.references.length; i++) {
+                  for (let i = 0; i < variable?.references?.length; i++) {
                     const ref = variable.references[i]
                     if (!ref.init) {
                       yield fixer.replaceTextRange(ref.identifier.range, pascal)

--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -5,6 +5,9 @@
 
 import { findVariable } from '@typescript-eslint/experimental-utils/dist/ast-utils'
 import { ExportNamedDeclaration } from '@typescript-eslint/types/dist/ast-spec'
+import { isExportStory } from '@storybook/csf'
+
+import { getDescriptor, getMetaObjectExpression } from '../utils'
 import { isIdentifier, isVariableDeclaration } from '../utils/ast'
 import { CategoryId } from '../utils/constants'
 import { createStorybookRule } from '../utils/create-storybook-rule'
@@ -57,11 +60,64 @@ export = createStorybookRule({
       )
     }
 
+    const checkAndReportError = (id, nonStoryExportsConfig = {}) => {
+      const { name } = id
+      if (!isExportStory(name, nonStoryExportsConfig)) {
+        return null
+      }
+
+      if (!isPascalCase(name)) {
+        context.report({
+          node: id,
+          messageId: 'usePascalCase',
+          data: {
+            name,
+          },
+          suggest: [
+            {
+              messageId: 'convertToPascalCase',
+              *fix(fixer: any) {
+                const fullText = context.getSourceCode().text
+                const fullName = fullText.slice(id.range[0], id.range[1])
+                const suffix = fullName.substring(name.length)
+                const pascal = toPascalCase(name)
+                yield fixer.replaceTextRange(id.range, pascal + suffix)
+
+                const scope = context.getScope().childScopes[0]
+                if (scope) {
+                  const variable = findVariable(scope, name)
+                  for (let i = 0; i < variable.references.length; i++) {
+                    const ref = variable.references[i]
+                    if (!ref.init) {
+                      yield fixer.replaceTextRange(ref.identifier.range, pascal)
+                    }
+                  }
+                }
+              },
+            },
+          ],
+        })
+      }
+    }
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
 
+    let meta
+    let nonStoryExportsConfig
+    let namedExports = []
+
     return {
+      ExportDefaultDeclaration: function (node: any) {
+        meta = getMetaObjectExpression(node, context)
+        if (meta) {
+          nonStoryExportsConfig = {
+            excludeStories: getDescriptor(meta, 'excludeStories'),
+            includeStories: getDescriptor(meta, 'includeStories'),
+          }
+        }
+      },
       ExportNamedDeclaration: function (node: ExportNamedDeclaration) {
         // if there are specifiers, node.declaration should be null
         if (!node.declaration) return
@@ -70,37 +126,13 @@ export = createStorybookRule({
         if (isVariableDeclaration(decl)) {
           const { id } = decl.declarations[0]
           if (isIdentifier(id)) {
-            const { name } = id
-            if (!isPascalCase(name)) {
-              context.report({
-                node: id,
-                messageId: 'usePascalCase',
-                data: {
-                  name,
-                },
-                suggest: [
-                  {
-                    messageId: 'convertToPascalCase',
-                    *fix(fixer: any) {
-                      const fullText = context.getSourceCode().text
-                      const fullName = fullText.slice(id.range[0], id.range[1])
-                      const suffix = fullName.substring(name.length)
-                      const pascal = toPascalCase(name)
-                      yield fixer.replaceTextRange(id.range, pascal + suffix)
-
-                      const variable = findVariable(context.getScope(), name)
-                      for (let i = 0; i < variable.references.length; i++) {
-                        const ref = variable.references[i]
-                        if (!ref.init) {
-                          yield fixer.replaceTextRange(ref.identifier.range, pascal)
-                        }
-                      }
-                    },
-                  },
-                ],
-              })
-            }
+            namedExports.push(id)
           }
+        }
+      },
+      'Program:exit': function () {
+        if (namedExports.length) {
+          namedExports.forEach((n) => checkAndReportError(n, nonStoryExportsConfig))
         }
       },
     }

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -25,3 +25,28 @@ export const getMetaObjectExpression = (node: ExportDefaultDeclaration, context:
 
   return isObjectExpression(meta) ? meta : null
 }
+
+export const getDescriptor = (metaDeclaration, propertyName) => {
+  const property =
+    metaDeclaration && metaDeclaration.properties.find((p) => p.key && p.key.name === propertyName)
+  if (!property) {
+    return undefined
+  }
+
+  const { type } = property.value
+
+  switch (type) {
+    case 'ArrayExpression':
+      return property.value.elements.map((t) => {
+        if (!['StringLiteral', 'Literal'].includes(t.type)) {
+          throw new Error(`Unexpected descriptor element: ${t.type}`)
+        }
+        return t.value
+      })
+    case 'Literal':
+    case 'RegExpLiteral':
+      return property.value.value
+    default:
+      throw new Error(`Unexpected descriptor: ${type}`)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "release": "yarn build && auto shipit"
   },
   "dependencies": {
+    "@storybook/csf": "^0.0.1",
     "@typescript-eslint/experimental-utils": "^5.3.0",
     "requireindex": "^1.1.0"
   },

--- a/tests/lib/rules/prefer-pascal-case.test.ts
+++ b/tests/lib/rules/prefer-pascal-case.test.ts
@@ -21,14 +21,20 @@ ruleTester.run('prefer-pascal-case', rule, {
   valid: [
     'export const Primary = {}',
     'export const Primary: Story = {}',
+    `
+      export default {
+        title: 'MyComponent',
+        component: MyComponent,
+        includeStories: ['SimpleStory', 'ComplexStory'],
+        excludeStories: /.*Data$/,
+      };
 
-    // @TODO: Support this use case - Non-story exports
-    // `
-    //   export default {
-    //     excludeStories: /.*Data$/,
-    //   }
-    //   export const getData = () => { data: 123 }
-    // `,
+      export const simpleData = { foo: 1, bar: 'baz' };
+      export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
+
+      export const SimpleStory = () => <MyComponent data={simpleData} />;
+      export const ComplexStory = () => <MyComponent data={complexData} />;
+    `,
   ],
 
   invalid: [
@@ -58,9 +64,9 @@ ruleTester.run('prefer-pascal-case', rule, {
     },
     {
       code: dedent`
-      export const primary: Story = {}
-      primary.foo = 'bar'
-    `,
+        export const primary: Story = {}
+        primary.foo = 'bar'
+      `,
       errors: [
         {
           messageId: 'usePascalCase',
@@ -74,6 +80,50 @@ ruleTester.run('prefer-pascal-case', rule, {
               output: dedent`
                 export const Primary: Story = {}
                 Primary.foo = 'bar'
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        export default {
+          title: 'MyComponent',
+          component: MyComponent,
+          includeStories: /.*Story$/,
+          excludeStories: /.*Data$/,
+        };
+
+        export const simpleData = { foo: 1, bar: 'baz' };
+        export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
+
+        export const simpleStory = () => <MyComponent data={simpleData} />;
+        simpleStory.args = {};
+      `,
+      errors: [
+        {
+          messageId: 'usePascalCase',
+          data: {
+            name: 'simpleStory',
+          },
+          type: AST_NODE_TYPES.Identifier,
+          suggestions: [
+            {
+              messageId: 'convertToPascalCase',
+              output: dedent`
+                export default {
+                  title: 'MyComponent',
+                  component: MyComponent,
+                  includeStories: /.*Story$/,
+                  excludeStories: /.*Data$/,
+                };
+
+                export const simpleData = { foo: 1, bar: 'baz' };
+                export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
+
+                export const SimpleStory = () => <MyComponent data={simpleData} />;
+                SimpleStory.args = {};
               `,
             },
           ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,6 +1469,13 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@storybook/csf@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@storybook/csf/-/csf-0.0.1.tgz#95901507dc02f0bc6f9ac8ee1983e2fc5bb98ce6"
+  integrity sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==
+  dependencies:
+    lodash "^4.17.15"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -4416,7 +4423,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. Don't forget to run `yarn update-all` to update configuration files and their documentation! -->

Added a check for non-story exports so that they are not impacted by the prefer-pascal-case rule

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
