### PR TITLE
no-title-property-in-meta: fix dangling comma and highlighting

### DIFF
--- a/lib/rules/no-title-property-in-meta.ts
+++ b/lib/rules/no-title-property-in-meta.ts
@@ -18,13 +18,12 @@ export = createStorybookRule({
     type: 'problem',
     fixable: 'code',
     docs: {
-      // @TODO check about this, as this only works in Typescript if the title property is optional, likely part of 6.4 typings
       description: 'Do not define a title in meta',
       categories: [CategoryId.CSF_STRICT],
       recommended: 'error',
     },
     messages: {
-      removeTitleInMeta: 'Do not define a title in meta',
+      removeTitleInMeta: 'Remove title property from meta',
       noTitleInMeta: `CSF3 does not need a title in meta`,
     },
     schema: [],
@@ -41,21 +40,23 @@ export = createStorybookRule({
 
         if (titleNode) {
           context.report({
-            node,
+            node: titleNode,
             messageId: 'noTitleInMeta',
-            // In case we want this to be auto fixed by --fix
-            // fix: function (fixer) {
-            //   return fixer.remove(
-            //     titleNode
-            //   )
-            // },
             suggest: [
               {
                 messageId: 'removeTitleInMeta',
-                fix: function (fixer: any) {
-                  // @TODO this suggestion keeps the comma and might result in error:
-                  // e.g. { title, args } becomes { , args }
-                  return fixer.remove(titleNode)
+                fix(fixer: any) {
+                  const fullText = context.getSourceCode().text
+                  const propertyTextWithExtraCharacter = fullText.slice(
+                    titleNode.range[0],
+                    titleNode.range[1] + 1
+                  )
+                  const hasComma = propertyTextWithExtraCharacter.slice(-1) === ','
+                  const propertyRange = [
+                    titleNode.range[0],
+                    hasComma ? titleNode.range[1] + 1 : titleNode.range[1],
+                  ]
+                  return fixer.removeRange(propertyRange)
                 },
               },
             ],

--- a/tests/lib/rules/no-title-property-in-meta.test.ts
+++ b/tests/lib/rules/no-title-property-in-meta.test.ts
@@ -25,15 +25,15 @@ ruleTester.run('no-title-property-in-meta', rule, {
 
   invalid: [
     {
-      code: "export default { component: Button, title: 'Button' }",
+      code: "export default { title: 'Button', component: Button }",
       errors: [
         {
           messageId: 'noTitleInMeta',
-          type: AST_NODE_TYPES.ExportDefaultDeclaration,
+          type: AST_NODE_TYPES.Property,
           suggestions: [
             {
               messageId: 'removeTitleInMeta',
-              output: 'export default { component: Button,  }',
+              output: 'export default {  component: Button }',
             },
           ],
         },
@@ -47,7 +47,7 @@ ruleTester.run('no-title-property-in-meta', rule, {
       errors: [
         {
           messageId: 'noTitleInMeta',
-          type: AST_NODE_TYPES.ExportDefaultDeclaration,
+          type: AST_NODE_TYPES.Property,
           suggestions: [
             {
               messageId: 'removeTitleInMeta',


### PR DESCRIPTION
Issue: N/A

## What Changed

Before, the highlighting was done in the entire meta. Now it's only in the title node:
![image](https://user-images.githubusercontent.com/1671563/141151748-55f841c1-11bb-494a-8060-0b04899ac8b3.png)

I also fixed an issue where if the code is like this:
```js
export default {
  title: 'Button',
  component: Button
}
```

would be fixed to this, leaving a comma:
```js
export default {
  ,
  component: Button
}
```

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
