### PR TITLE
hierarchy-separator: fix node highlight

### DIFF
--- a/lib/rules/hierarchy-separator.ts
+++ b/lib/rules/hierarchy-separator.ts
@@ -50,7 +50,7 @@ export = createStorybookRule({
 
         if (metaTitle.includes('|') || metaTitle.includes('.')) {
           context.report({
-            node,
+            node: titleNode,
             messageId: 'deprecatedHierarchySeparator',
             data: { metaTitle },
             // In case we want this to be auto fixed by --fix

--- a/tests/lib/rules/hierarchy-separator.test.ts
+++ b/tests/lib/rules/hierarchy-separator.test.ts
@@ -29,7 +29,7 @@ ruleTester.run('hierarchy-separator', rule, {
       output: "export default { title: 'Examples/Components/Button' }",
       errors: [
         {
-          type: AST_NODE_TYPES.ExportDefaultDeclaration,
+          type: AST_NODE_TYPES.Property,
           messageId: 'deprecatedHierarchySeparator',
           suggestions: [
             {
@@ -45,7 +45,7 @@ ruleTester.run('hierarchy-separator', rule, {
       output: "export default { title: 'Examples/Components/Button' }",
       errors: [
         {
-          type: AST_NODE_TYPES.ExportDefaultDeclaration,
+          type: AST_NODE_TYPES.Property,
           messageId: 'deprecatedHierarchySeparator',
           suggestions: [
             {
@@ -67,7 +67,7 @@ ruleTester.run('hierarchy-separator', rule, {
       `,
       errors: [
         {
-          type: AST_NODE_TYPES.ExportDefaultDeclaration,
+          type: AST_NODE_TYPES.Property,
           messageId: 'deprecatedHierarchySeparator',
           suggestions: [
             {


### PR DESCRIPTION
Issue: N/A

## What Changed

The highlighting of the rule was being applied to the entire meta. Now it does only for the title node:

![image](https://user-images.githubusercontent.com/1671563/141152575-25e43025-bc38-4e83-9b2d-c1f99ef077c1.png)


## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
