### PR TITLE
Add autofix heuristics for default-exports rule

### DIFF
--- a/lib/rules/csf-component.ts
+++ b/lib/rules/csf-component.ts
@@ -4,7 +4,6 @@
  */
 
 import { ExportDefaultDeclaration, Node } from '@typescript-eslint/types/dist/ast-spec'
-import { isObjectExpression } from '../utils/ast'
 import { getMetaObjectExpression } from '../utils'
 import { CategoryId } from '../utils/constants'
 import { createStorybookRule } from '../utils/create-storybook-rule'

--- a/tests/lib/rules/default-exports.test.ts
+++ b/tests/lib/rules/default-exports.test.ts
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 import { AST_NODE_TYPES } from '@typescript-eslint/types'
+import dedent from 'ts-dedent'
 
 import rule from '../../../lib/rules/default-exports'
 import ruleTester from '../../utils/rule-tester'
@@ -33,6 +34,60 @@ ruleTester.run('default-exports', rule, {
   invalid: [
     {
       code: 'export const Primary = () => <button>hello</button>',
+      errors: [
+        {
+          messageId: 'shouldHaveDefaultExport',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { MyComponent, Foo } from './MyComponent'
+        export const Primary = () => <button>hello</button>
+      `,
+      output: dedent`
+        import { MyComponent, Foo } from './MyComponent'
+        export default { component: MyComponent }
+        export const Primary = () => <button>hello</button>
+      `,
+      errors: [
+        {
+          messageId: 'shouldHaveDefaultExport',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import MyComponent from './MyComponent'
+        export const Primary = () => <button>hello</button>
+      `,
+      output: dedent`
+        import MyComponent from './MyComponent'
+        export default { component: MyComponent }
+        export const Primary = () => <button>hello</button>
+      `,
+      errors: [
+        {
+          messageId: 'shouldHaveDefaultExport',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { Something } from './MyComponent'
+        export const Primary = () => <button>hello</button>
+      `,
+      errors: [
+        {
+          messageId: 'shouldHaveDefaultExport',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { MyComponent } from './Something'
+        export const Primary = () => <button>hello</button>
+      `,
       errors: [
         {
           messageId: 'shouldHaveDefaultExport',


### PR DESCRIPTION
Issue: N/A

## What Changed

```
import { MyComponent } from './MyComponent'
```
=>

```
import { MyComponent } from './MyComponent'
export { component: MyComponent }
```

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
