### PR TITLE
hierarchy-separator: remove dot from checkings

### DIFF
--- a/lib/rules/hierarchy-separator.ts
+++ b/lib/rules/hierarchy-separator.ts
@@ -48,7 +48,7 @@ export = createStorybookRule({
         //@ts-ignore
         const metaTitle = titleNode.value.raw || ''
 
-        if (metaTitle.includes('|') || metaTitle.includes('.')) {
+        if (metaTitle.includes('|')) {
           context.report({
             node: titleNode,
             messageId: 'deprecatedHierarchySeparator',
@@ -58,7 +58,7 @@ export = createStorybookRule({
               return fixer.replaceTextRange(
                 //@ts-ignore
                 titleNode.value.range,
-                metaTitle.replace(/\||\./g, '/')
+                metaTitle.replace(/\|/g, '/')
               )
             },
             suggest: [
@@ -68,7 +68,7 @@ export = createStorybookRule({
                   return fixer.replaceTextRange(
                     //@ts-ignore
                     titleNode.value.range,
-                    metaTitle.replace(/\||\./g, '/')
+                    metaTitle.replace(/\|/g, '/')
                   )
                 },
               },

--- a/tests/lib/rules/hierarchy-separator.test.ts
+++ b/tests/lib/rules/hierarchy-separator.test.ts
@@ -19,13 +19,14 @@ import ruleTester from '../../utils/rule-tester'
 
 ruleTester.run('hierarchy-separator', rule, {
   valid: [
+    "export default { title: 'Examples.Components' }",
     "export default { title: 'Examples/Components/Button' }",
     "export default { title: 'Examples/Components/Button' } as ComponentMeta<typeof Button>",
   ],
 
   invalid: [
     {
-      code: "export default { title: 'Examples|Components|Button' }",
+      code: "export default { title: 'Examples|Components/Button' }",
       output: "export default { title: 'Examples/Components/Button' }",
       errors: [
         {
@@ -41,7 +42,7 @@ ruleTester.run('hierarchy-separator', rule, {
       ],
     },
     {
-      code: "export default { title: 'Examples.Components.Button' }",
+      code: "export default { title: 'Examples|Components/Button' }",
       output: "export default { title: 'Examples/Components/Button' }",
       errors: [
         {
@@ -58,7 +59,7 @@ ruleTester.run('hierarchy-separator', rule, {
     },
     {
       code: dedent`
-        const meta = { title: 'Examples.Components.Button' }
+        const meta = { title: 'Examples|Components/Button' }
         export default meta
       `,
       output: dedent`


### PR DESCRIPTION
Issue: N/A

## What Changed

Regarding hierarchy-separators, the dot can be used for normal names and adds confusion. Given it's a pretty old convention I think it's safe to just ignore the dot and check only for pipe instead.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
