### PR TITLE
prefer-pascal-case: ignore stories that start with underscore

### DIFF
--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -66,7 +66,7 @@ export = createStorybookRule({
         return null
       }
 
-      if (!isPascalCase(name)) {
+      if (!name.startsWith('_') && !isPascalCase(name)) {
         context.report({
           node: id,
           messageId: 'usePascalCase',

--- a/tests/lib/rules/prefer-pascal-case.test.ts
+++ b/tests/lib/rules/prefer-pascal-case.test.ts
@@ -21,6 +21,7 @@ ruleTester.run('prefer-pascal-case', rule, {
   valid: [
     'export const Primary = {}',
     `export const __namedExportsOrder = ['Secondary', 'Primary']`,
+    `export const _primary = {}`,
     'export const Primary: Story = {}',
     `
       export default {


### PR DESCRIPTION
Issue: N/A

## What Changed

Stories that start with underscore should be ignored as they might be written like that to avoid name collision with the components

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
