### PR TITLE
ignore storiesOf in default-export and prefer-pascal-case

### DIFF
--- a/lib/rules/default-exports.ts
+++ b/lib/rules/default-exports.ts
@@ -61,8 +61,14 @@ export = createStorybookRule({
     //----------------------------------------------------------------------
 
     let hasDefaultExport = false
+    let hasStoriesOfImport = false
 
     return {
+      ImportSpecifier(node: any) {
+        if (node.imported.name === 'storiesOf') {
+          hasStoriesOfImport = true
+        }
+      },
       ExportDefaultSpecifier: function () {
         hasDefaultExport = true
       },
@@ -70,7 +76,7 @@ export = createStorybookRule({
         hasDefaultExport = true
       },
       'Program:exit': function (program: Program) {
-        if (!hasDefaultExport) {
+        if (!hasDefaultExport && !hasStoriesOfImport) {
           const componentName = getComponentName(program, context.getFilename())
           const firstNonImportStatement = program.body.find((n) => !isImportDeclaration(n))
           const node = firstNonImportStatement || program.body[0] || program

--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -107,8 +107,14 @@ export = createStorybookRule({
     let meta
     let nonStoryExportsConfig
     let namedExports = []
+    let hasStoriesOfImport = false
 
     return {
+      ImportSpecifier(node: any) {
+        if (node.imported.name === 'storiesOf') {
+          hasStoriesOfImport = true
+        }
+      },
       ExportDefaultDeclaration: function (node: any) {
         meta = getMetaObjectExpression(node, context)
         if (meta) {
@@ -131,7 +137,7 @@ export = createStorybookRule({
         }
       },
       'Program:exit': function () {
-        if (namedExports.length) {
+        if (namedExports.length && !hasStoriesOfImport) {
           namedExports.forEach((n) => checkAndReportError(n, nonStoryExportsConfig))
         }
       },

--- a/tests/lib/rules/default-exports.test.ts
+++ b/tests/lib/rules/default-exports.test.ts
@@ -29,6 +29,10 @@ ruleTester.run('default-exports', rule, {
       const meta: ComponentMeta<typeof Button> = { title: 'Button', component: Button }
       export default meta
     `,
+    `
+      import { storiesOf } from '@storybook/react'
+      storiesOf('Component', module)
+    `,
   ],
 
   invalid: [

--- a/tests/lib/rules/prefer-pascal-case.test.ts
+++ b/tests/lib/rules/prefer-pascal-case.test.ts
@@ -23,6 +23,11 @@ ruleTester.run('prefer-pascal-case', rule, {
     `export const __namedExportsOrder = ['Secondary', 'Primary']`,
     'export const Primary: Story = {}',
     `
+      import { storiesOf } from '@storybook/react'
+      export const links = []
+      storiesOf('Component', module)
+    `,
+    `
       export default {
         title: 'MyComponent',
         component: MyComponent,


### PR DESCRIPTION
Issue: N/A

## What Changed

Both `default-export` and `prefer-pascal-case` rules should not be applied to older formats (storiesOf)

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
