### PR TITLE
Rule: add story-exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,18 +96,19 @@ This plugin does not support MDX files.
 
 **Configurations**: csf, csf-strict, addon-interactions, recommended
 
-| Name                                                                                       | Description                                       | 🔧  | Included in configurations                               |
-| ------------------------------------------------------------------------------------------ | ------------------------------------------------- | --- | -------------------------------------------------------- |
-| [`storybook/await-interactions`](./docs/rules/await-interactions.md)                       | Interactions should be awaited                    | 🔧  | <ul><li>addon-interactions</li><li>recommended</li></ul> |
-| [`storybook/csf-component`](./docs/rules/csf-component.md)                                 | The component property should be set              |     | <ul><li>csf</li></ul>                                    |
-| [`storybook/default-exports`](./docs/rules/default-exports.md)                             | Story files should have a default export          | 🔧  | <ul><li>csf</li><li>recommended</li></ul>                |
-| [`storybook/hierarchy-separator`](./docs/rules/hierarchy-separator.md)                     | Deprecated hierachy separator in title property   | 🔧  | <ul><li>csf</li><li>recommended</li></ul>                |
-| [`storybook/no-redundant-story-name`](./docs/rules/no-redundant-story-name.md)             | A story should not have a redundant name property | 🔧  | <ul><li>csf</li><li>recommended</li></ul>                |
-| [`storybook/no-stories-of`](./docs/rules/no-stories-of.md)                                 | storiesOf is deprecated and should not be used    |     | <ul><li>csf-strict</li></ul>                             |
-| [`storybook/no-title-property-in-meta`](./docs/rules/no-title-property-in-meta.md)         | Do not define a title in meta                     | 🔧  | <ul><li>csf-strict</li></ul>                             |
-| [`storybook/prefer-pascal-case`](./docs/rules/prefer-pascal-case.md)                       | Stories should use PascalCase                     | 🔧  | <ul><li>recommended</li></ul>                            |
-| [`storybook/use-storybook-expect`](./docs/rules/use-storybook-expect.md)                   | Use expect from `@storybook/jest`                 | 🔧  | <ul><li>addon-interactions</li><li>recommended</li></ul> |
-| [`storybook/use-storybook-testing-library`](./docs/rules/use-storybook-testing-library.md) | Do not use testing-library directly on stories    | 🔧  | <ul><li>addon-interactions</li><li>recommended</li></ul> |
+| Name                                                                                       | Description                                         | 🔧  | Included in configurations                               |
+| ------------------------------------------------------------------------------------------ | --------------------------------------------------- | --- | -------------------------------------------------------- |
+| [`storybook/await-interactions`](./docs/rules/await-interactions.md)                       | Interactions should be awaited                      | 🔧  | <ul><li>addon-interactions</li><li>recommended</li></ul> |
+| [`storybook/csf-component`](./docs/rules/csf-component.md)                                 | The component property should be set                |     | <ul><li>csf</li></ul>                                    |
+| [`storybook/default-exports`](./docs/rules/default-exports.md)                             | Story files should have a default export            | 🔧  | <ul><li>csf</li><li>recommended</li></ul>                |
+| [`storybook/hierarchy-separator`](./docs/rules/hierarchy-separator.md)                     | Deprecated hierachy separator in title property     | 🔧  | <ul><li>csf</li><li>recommended</li></ul>                |
+| [`storybook/no-redundant-story-name`](./docs/rules/no-redundant-story-name.md)             | A story should not have a redundant name property   | 🔧  | <ul><li>csf</li><li>recommended</li></ul>                |
+| [`storybook/no-stories-of`](./docs/rules/no-stories-of.md)                                 | storiesOf is deprecated and should not be used      |     | <ul><li>csf-strict</li></ul>                             |
+| [`storybook/no-title-property-in-meta`](./docs/rules/no-title-property-in-meta.md)         | Do not define a title in meta                       | 🔧  | <ul><li>csf-strict</li></ul>                             |
+| [`storybook/prefer-pascal-case`](./docs/rules/prefer-pascal-case.md)                       | Stories should use PascalCase                       | 🔧  | <ul><li>recommended</li></ul>                            |
+| [`storybook/story-exports`](./docs/rules/story-exports.md)                                 | A story file must contain at least one story export | 🔧  | <ul><li>recommended</li><li>csf</li></ul>                |
+| [`storybook/use-storybook-expect`](./docs/rules/use-storybook-expect.md)                   | Use expect from `@storybook/jest`                   | 🔧  | <ul><li>addon-interactions</li><li>recommended</li></ul> |
+| [`storybook/use-storybook-testing-library`](./docs/rules/use-storybook-testing-library.md) | Do not use testing-library directly on stories      | 🔧  | <ul><li>addon-interactions</li><li>recommended</li></ul> |
 
 <!-- RULES-LIST:END -->
 

--- a/docs/rules/story-exports.md
+++ b/docs/rules/story-exports.md
@@ -1,0 +1,41 @@
+# story-exports
+
+<!-- RULE-CATEGORIES:START -->
+
+**Included in these configurations**: <ul><li>recommended</li><li>csf</li></ul>
+
+<!-- RULE-CATEGORIES:END -->
+
+## Rule Details
+
+In [CSF](https://storybook.js.org/docs/react/writing-stories/introduction#component-story-format), a story file should contain a _default export_ that describes the component, and at _named exports_ that describe the stories. This rule enforces the definition of at least one named export in story files.
+
+Examples of **incorrect** code for this rule:
+
+```js
+export default {
+  title: 'Button',
+  args: { primary: true },
+  component: Button,
+}
+// no named export
+```
+
+Examples of **correct** code for this rule:
+
+```js
+export default {
+  title: 'Button',
+  args: { primary: true },
+  component: Button,
+}
+export const Primary = {} // at least one named export!
+```
+
+## When Not To Use It
+
+This rule should only be applied in your `.stories.*` files. Please ensure you are defining the storybook rules only for story files. You can see more details [here](https://github.com/storybookjs/eslint-plugin-storybook#eslint-overrides).
+
+## Further Reading
+
+More information about defining stories here: https://storybook.js.org/docs/react/writing-stories/introduction#defining-stories

--- a/lib/configs/csf.ts
+++ b/lib/configs/csf.ts
@@ -14,6 +14,7 @@ export = {
         'storybook/default-exports': 'error',
         'storybook/hierarchy-separator': 'warn',
         'storybook/no-redundant-story-name': 'warn',
+        'storybook/story-exports': 'error',
       },
     },
   ],

--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -15,6 +15,7 @@ export = {
         'storybook/hierarchy-separator': 'warn',
         'storybook/no-redundant-story-name': 'warn',
         'storybook/prefer-pascal-case': 'warn',
+        'storybook/story-exports': 'error',
         'storybook/use-storybook-expect': 'error',
         'storybook/use-storybook-testing-library': 'error',
       },

--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -89,7 +89,7 @@ export = createStorybookRule({
           return
         }
 
-        const fix = (fixer) => fixer.insertTextAfter(node, `\nexport const Default = {}\n`)
+        const fix = (fixer) => fixer.insertTextAfter(node, `\n\nexport const Default = {}`)
 
         context.report({
           node,

--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview A story file must contain at least one story export
+ * @author Yann Braga
+ */
+
+import { isExportStory } from '@storybook/csf'
+
+import { createStorybookRule } from '../utils/create-storybook-rule'
+import { CategoryId } from '../utils/constants'
+import { getDescriptor, getMetaObjectExpression } from '../utils'
+import { isIdentifier, isVariableDeclaration } from '../utils/ast'
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+export = createStorybookRule({
+  name: 'story-exports',
+  defaultOptions: [],
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'A story file must contain at least one story export',
+      categories: [CategoryId.RECOMMENDED, CategoryId.CSF],
+      recommended: 'error',
+    },
+    messages: {
+      shouldHaveStoryExport: 'The file should have at least one story export',
+      addStoryExport: 'Add a story export',
+    },
+    fixable: 'code',
+    schema: [],
+  },
+
+  create(context) {
+    // variables should be defined here
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    const isValidStoryExport = (node) =>
+      isExportStory(node.name, nonStoryExportsConfig) && node.name !== '__namedExportsOrder'
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    let hasStoriesOfImport = false
+    let nonStoryExportsConfig = {}
+    let meta
+    let namedExports = []
+
+    return {
+      ImportSpecifier(node) {
+        if (node.imported.name === 'storiesOf') {
+          hasStoriesOfImport = true
+        }
+      },
+      ExportDefaultDeclaration: function (node) {
+        meta = getMetaObjectExpression(node, context)
+        if (meta) {
+          nonStoryExportsConfig = {
+            excludeStories: getDescriptor(meta, 'excludeStories'),
+            includeStories: getDescriptor(meta, 'includeStories'),
+          }
+        }
+      },
+      ExportNamedDeclaration: function (node) {
+        // if there are specifiers, node.declaration should be null
+        if (!node.declaration) return
+
+        const decl = node.declaration
+        if (isVariableDeclaration(decl)) {
+          const { id } = decl.declarations[0]
+          if (isIdentifier(id)) {
+            namedExports.push(id)
+          }
+        }
+      },
+      'Program:exit': function (node) {
+        if (hasStoriesOfImport || !meta) {
+          return
+        }
+
+        const storyExports = namedExports.filter(isValidStoryExport)
+
+        if (storyExports.length) {
+          return
+        }
+
+        const fix = (fixer) => fixer.insertTextAfter(node, `\nexport const Default = {}\n`)
+
+        context.report({
+          node,
+          messageId: 'shouldHaveStoryExport',
+          fix,
+        })
+      },
+    }
+  },
+})

--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -89,12 +89,13 @@ export = createStorybookRule({
           return
         }
 
-        const fix = (fixer) => fixer.insertTextAfter(node, `\n\nexport const Default = {}`)
+        // @TODO: bring apply this autofix with CSF3 release
+        // const fix = (fixer) => fixer.insertTextAfter(node, `\n\nexport const Default = {}`)
 
         context.report({
           node,
           messageId: 'shouldHaveStoryExport',
-          fix,
+          // fix,
         })
       },
     }

--- a/tests/lib/rules/story-exports.test.ts
+++ b/tests/lib/rules/story-exports.test.ts
@@ -36,28 +36,17 @@ ruleTester.run('story-exports', rule, {
       code: dedent`
         export default {
           component: Button
-        } as ComponentMeta<typeof RestaurantDetailPage>
-      `,
+        } as ComponentMeta<typeof RestaurantDetailPage>`,
       output: dedent`
         export default {
           component: Button
         } as ComponentMeta<typeof RestaurantDetailPage>
+
         export const Default = {}
       `,
       errors: [
         {
           messageId: 'shouldHaveStoryExport',
-          suggestions: [
-            {
-              messageId: 'addStoryExport',
-              output: dedent`
-                export default {
-                  component: Button
-                } as ComponentMeta<typeof RestaurantDetailPage>
-                export const Default = {}
-              `,
-            },
-          ],
         },
       ],
     },
@@ -66,30 +55,21 @@ ruleTester.run('story-exports', rule, {
         export default {
           excludeStories: /.*Data$/,
         }
+
         export const mockData = {}
       `,
       output: dedent`
         export default {
           excludeStories: /.*Data$/,
         }
+
         export const mockData = {}
+
         export const Default = {}
       `,
       errors: [
         {
           messageId: 'shouldHaveStoryExport',
-          suggestions: [
-            {
-              messageId: 'addStoryExport',
-              output: dedent`
-                export default {
-                  excludeStories: /.*Data$/,
-                }
-                export const mockData = {}
-                export const Default = {}
-              `,
-            },
-          ],
         },
       ],
     },

--- a/tests/lib/rules/story-exports.test.ts
+++ b/tests/lib/rules/story-exports.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @fileoverview A story file must contain at least one story export
+ * @author Yann Braga
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import dedent from 'ts-dedent'
+import rule from '../../../lib/rules/story-exports'
+import ruleTester from '../../utils/rule-tester'
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+ruleTester.run('story-exports', rule, {
+  valid: [
+    'export const Primary = {}',
+    `
+      export default {}
+      export const Primary = {}
+    `,
+    `
+      export default {} as ComponentMeta<typeof RestaurantDetailPage>
+      export const Primary = {}
+    `,
+    `
+      import { storiesOf } from '@storybook/react'
+      storiesOf('MyComponent', module)
+    `,
+  ],
+  invalid: [
+    {
+      code: dedent`
+        export default {
+          component: Button
+        } as ComponentMeta<typeof RestaurantDetailPage>
+      `,
+      output: dedent`
+        export default {
+          component: Button
+        } as ComponentMeta<typeof RestaurantDetailPage>
+        export const Default = {}
+      `,
+      errors: [
+        {
+          messageId: 'shouldHaveStoryExport',
+          suggestions: [
+            {
+              messageId: 'addStoryExport',
+              output: dedent`
+                export default {
+                  component: Button
+                } as ComponentMeta<typeof RestaurantDetailPage>
+                export const Default = {}
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        export default {
+          excludeStories: /.*Data$/,
+        }
+        export const mockData = {}
+      `,
+      output: dedent`
+        export default {
+          excludeStories: /.*Data$/,
+        }
+        export const mockData = {}
+        export const Default = {}
+      `,
+      errors: [
+        {
+          messageId: 'shouldHaveStoryExport',
+          suggestions: [
+            {
+              messageId: 'addStoryExport',
+              output: dedent`
+                export default {
+                  excludeStories: /.*Data$/,
+                }
+                export const mockData = {}
+                export const Default = {}
+              `,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})

--- a/tests/lib/rules/story-exports.test.ts
+++ b/tests/lib/rules/story-exports.test.ts
@@ -37,13 +37,13 @@ ruleTester.run('story-exports', rule, {
         export default {
           component: Button
         } as ComponentMeta<typeof RestaurantDetailPage>`,
-      output: dedent`
-        export default {
-          component: Button
-        } as ComponentMeta<typeof RestaurantDetailPage>
+      // output: dedent`
+      //   export default {
+      //     component: Button
+      //   } as ComponentMeta<typeof RestaurantDetailPage>
 
-        export const Default = {}
-      `,
+      //   export const Default = {}
+      // `,
       errors: [
         {
           messageId: 'shouldHaveStoryExport',
@@ -58,15 +58,15 @@ ruleTester.run('story-exports', rule, {
 
         export const mockData = {}
       `,
-      output: dedent`
-        export default {
-          excludeStories: /.*Data$/,
-        }
+      // output: dedent`
+      //   export default {
+      //     excludeStories: /.*Data$/,
+      //   }
 
-        export const mockData = {}
+      //   export const mockData = {}
 
-        export const Default = {}
-      `,
+      //   export const Default = {}
+      // `,
       errors: [
         {
           messageId: 'shouldHaveStoryExport',

--- a/tools/generate-rule.ts
+++ b/tools/generate-rule.ts
@@ -163,7 +163,7 @@ const generateRule = async () => {
       # ${ruleId}
 
       <!-- RULE-CATEGORIES:START -->
-      <!-- RULE-LIST:END -->
+      <!-- RULE-CATEGORIES:END -->
 
       ## Rule Details
 


### PR DESCRIPTION
Issue: #42

## What Changed

Added a new rule `story-exports` to enforce defining at least one named export in a story file.

## Checklist

Check the ones applicable to your change:

- [x] Ran `yarn update-all`
- [x] Tests are updated
- [x] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`
