### PR TITLE
Fix: define hasSuggestions to all fixable rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This plugin does not support MDX files.
 | [`storybook/no-stories-of`](./docs/rules/no-stories-of.md)                                 | storiesOf is deprecated and should not be used              |     | <ul><li>csf-strict</li></ul>                             |
 | [`storybook/no-title-property-in-meta`](./docs/rules/no-title-property-in-meta.md)         | Do not define a title in meta                               | 🔧  | <ul><li>csf-strict</li></ul>                             |
 | [`storybook/prefer-pascal-case`](./docs/rules/prefer-pascal-case.md)                       | Stories should use PascalCase                               | 🔧  | <ul><li>recommended</li></ul>                            |
-| [`storybook/story-exports`](./docs/rules/story-exports.md)                                 | A story file must contain at least one story export         | 🔧  | <ul><li>recommended</li><li>csf</li></ul>                |
+| [`storybook/story-exports`](./docs/rules/story-exports.md)                                 | A story file must contain at least one story export         |     | <ul><li>recommended</li><li>csf</li></ul>                |
 | [`storybook/use-storybook-expect`](./docs/rules/use-storybook-expect.md)                   | Use expect from `@storybook/jest`                           | 🔧  | <ul><li>addon-interactions</li><li>recommended</li></ul> |
 | [`storybook/use-storybook-testing-library`](./docs/rules/use-storybook-testing-library.md) | Do not use testing-library directly on stories              | 🔧  | <ul><li>addon-interactions</li><li>recommended</li></ul> |
 

--- a/lib/rules/await-interactions.ts
+++ b/lib/rules/await-interactions.ts
@@ -36,6 +36,7 @@ export = createStorybookRule({
     },
     type: 'problem',
     fixable: 'code',
+    hasSuggestions: true,
     schema: [],
   },
 

--- a/lib/rules/default-exports.ts
+++ b/lib/rules/default-exports.ts
@@ -29,6 +29,7 @@ export = createStorybookRule({
       fixSuggestion: 'Add default export',
     },
     fixable: 'code',
+    hasSuggestions: true,
     schema: [],
   },
 

--- a/lib/rules/hierarchy-separator.ts
+++ b/lib/rules/hierarchy-separator.ts
@@ -18,6 +18,7 @@ export = createStorybookRule({
   meta: {
     type: 'problem',
     fixable: 'code',
+    hasSuggestions: true,
     docs: {
       description: 'Deprecated hierachy separator in title property',
       categories: [CategoryId.CSF, CategoryId.RECOMMENDED],

--- a/lib/rules/no-redundant-story-name.ts
+++ b/lib/rules/no-redundant-story-name.ts
@@ -24,6 +24,7 @@ export = createStorybookRule({
   meta: {
     type: 'suggestion',
     fixable: 'code',
+    hasSuggestions: true,
     docs: {
       description: 'A story should not have a redundant name property',
       categories: [CategoryId.CSF, CategoryId.RECOMMENDED],

--- a/lib/rules/no-title-property-in-meta.ts
+++ b/lib/rules/no-title-property-in-meta.ts
@@ -17,6 +17,7 @@ export = createStorybookRule({
   meta: {
     type: 'problem',
     fixable: 'code',
+    hasSuggestions: true,
     docs: {
       description: 'Do not define a title in meta',
       categories: [CategoryId.CSF_STRICT],

--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -21,7 +21,8 @@ export = createStorybookRule({
   defaultOptions: [],
   meta: {
     type: 'suggestion',
-    fixable: 'code', // Or `code` or `whitespace`
+    fixable: 'code',
+    hasSuggestions: true,
     docs: {
       description: 'Stories should use PascalCase',
       categories: [CategoryId.RECOMMENDED],

--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -28,7 +28,7 @@ export = createStorybookRule({
       shouldHaveStoryExport: 'The file should have at least one story export',
       addStoryExport: 'Add a story export',
     },
-    fixable: 'code',
+    fixable: null, // change to 'code' once we have autofixes
     schema: [],
   },
 

--- a/lib/rules/use-storybook-expect.ts
+++ b/lib/rules/use-storybook-expect.ts
@@ -23,7 +23,7 @@ export = createStorybookRule({
   defaultOptions: [],
   meta: {
     type: 'suggestion',
-    fixable: 'code', // Or `code` or `whitespace`,
+    fixable: 'code',
     hasSuggestions: true,
     schema: [],
     docs: {

--- a/lib/rules/use-storybook-testing-library.ts
+++ b/lib/rules/use-storybook-testing-library.ts
@@ -15,7 +15,7 @@ export = createStorybookRule({
   defaultOptions: [],
   meta: {
     type: 'suggestion',
-    fixable: 'code', // Or `code` or `whitespace`
+    fixable: 'code',
     hasSuggestions: true,
     docs: {
       description: 'Do not use testing-library directly on stories',

--- a/tools/generate-rule.ts
+++ b/tools/generate-rule.ts
@@ -14,7 +14,7 @@ const questions = [
     name: 'authorName',
     initial: '',
     message: 'What is your name?',
-    validate: (name: any) => (name === '' ? "Name can't be empty" : true),
+    validate: (name: string) => (name === '' ? "Name can't be empty" : true),
   },
   {
     type: 'text',
@@ -25,18 +25,24 @@ const questions = [
       - If your rule is enforcing the inclusion of something, use a short name without a special prefix.
       - Use dashes between words.
     `),
-    validate: (rule: any) => (rule === '' ? "Rule can't be empty" : true),
+    validate: (rule: string) => (rule === '' ? "Rule can't be empty" : true),
   },
   {
     type: 'text',
     name: 'ruleDescription',
     message: 'Type a short description of this rule',
-    validate: (rule: any) => (rule === '' ? "Description can't be empty" : true),
+    validate: (rule: string) => (rule === '' ? "Description can't be empty" : true),
+  },
+  {
+    type: 'confirm',
+    name: 'isAutoFixable',
+    message: 'Will this rule contain an autofix?',
+    initial: true,
   },
 ]
 
 const generateRule = async () => {
-  const { authorName, ruleId, ruleDescription } = await prompts(questions)
+  const { authorName, ruleId, ruleDescription, isAutoFixable } = await prompts(questions)
 
   if (!authorName) {
     logger.log('Process canceled by the user.')
@@ -76,7 +82,8 @@ const generateRule = async () => {
           messages: {
             anyMessageIdHere: 'Fill me in',
           },
-          fixable: null, // Or \`code\` or \`whitespace\`
+          ${isAutoFixable ? "fixable: 'code'," : ''}
+          ${isAutoFixable ? 'hasSuggestions: true,' : ''}
           schema: [], // Add a schema if the rule has options. Otherwise remove this
         },
 
@@ -212,8 +219,10 @@ const generateRule = async () => {
     cp.execSync(`code "${docFile}"`)
   }
 
-  logger.log('\n🚀 All done! Make sure to run yarn test as you write the rule.')
-  logger.log('❤️  Thanks for helping this plugin get better!')
+  logger.log(
+    '\n🚀 All done! Make sure to run `yarn test` as you write the rule and `yarn update-all` when you are done.'
+  )
+  logger.log(`❤️  Thanks for helping this plugin get better, ${authorName.split(' ')[0]}!`)
 }
 
 generateRule()


### PR DESCRIPTION
Issue: #54 

## What Changed

- All fixable rules now define hasSuggestions
- `yarn generate-rule` improved to reflect that new change

## Checklist

Check the ones applicable to your change:

- [x] Ran `yarn update-all`
- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
