### PR TITLE
extend story-exports rule to support export lists, fixes #57

### DIFF
--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -67,16 +67,27 @@ export = createStorybookRule({
         }
       },
       ExportNamedDeclaration: function (node) {
-        // if there are specifiers, node.declaration should be null
-        if (!node.declaration) return
+        if (node.type !== "ExportNamedDeclaration") return
 
-        const decl = node.declaration
-        if (isVariableDeclaration(decl)) {
-          const { id } = decl.declarations[0]
-          if (isIdentifier(id)) {
-            namedExports.push(id)
+        // Handle individual exports
+        // "if there are specifiers, node.declaration should be null"
+        if (node.declaration) {
+          const decl = node.declaration
+          if (isVariableDeclaration(decl)) {
+            const { id } = decl.declarations[0]
+            if (isIdentifier(id)) {
+              namedExports.push(id)
+            }
           }
         }
+        // Handle export lists
+        let exportListSpecifiers = node.specifiers.filter((specifier) => specifier.type === "ExportSpecifier")
+        exportListSpecifiers.forEach((specifier) => {
+          const { local } = specifier;
+          if (isIdentifier(local)) {
+            namedExports.push(local)
+          }
+        });
       },
       'Program:exit': function (node) {
         if (hasStoriesOfImport || !meta) {

--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -3,12 +3,14 @@
  * @author Yann Braga
  */
 
-import { isExportStory } from '@storybook/csf'
-
 import { createStorybookRule } from '../utils/create-storybook-rule'
 import { CategoryId } from '../utils/constants'
-import { getDescriptor, getMetaObjectExpression } from '../utils'
-import { isIdentifier, isVariableDeclaration } from '../utils/ast'
+import {
+  getAllNamedExports,
+  getDescriptor,
+  getMetaObjectExpression,
+  isValidStoryExport,
+} from '../utils'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -39,9 +41,6 @@ export = createStorybookRule({
     // Helpers
     //----------------------------------------------------------------------
 
-    const isValidStoryExport = (node) =>
-      isExportStory(node.name, nonStoryExportsConfig) && node.name !== '__namedExportsOrder'
-
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
@@ -67,34 +66,16 @@ export = createStorybookRule({
         }
       },
       ExportNamedDeclaration: function (node) {
-        if (node.type !== "ExportNamedDeclaration") return
-
-        // Handle individual exports
-        // "if there are specifiers, node.declaration should be null"
-        if (node.declaration) {
-          const decl = node.declaration
-          if (isVariableDeclaration(decl)) {
-            const { id } = decl.declarations[0]
-            if (isIdentifier(id)) {
-              namedExports.push(id)
-            }
-          }
-        }
-        // Handle export lists
-        let exportListSpecifiers = node.specifiers.filter((specifier) => specifier.type === "ExportSpecifier")
-        exportListSpecifiers.forEach((specifier) => {
-          const { local } = specifier;
-          if (isIdentifier(local)) {
-            namedExports.push(local)
-          }
-        });
+        namedExports.push(...getAllNamedExports(node))
       },
       'Program:exit': function (node) {
         if (hasStoriesOfImport || !meta) {
           return
         }
 
-        const storyExports = namedExports.filter(isValidStoryExport)
+        const storyExports = namedExports.filter((exp) =>
+          isValidStoryExport(exp, nonStoryExportsConfig)
+        )
 
         if (storyExports.length) {
           return

--- a/tests/lib/rules/story-exports.test.ts
+++ b/tests/lib/rules/story-exports.test.ts
@@ -30,6 +30,22 @@ ruleTester.run('story-exports', rule, {
       import { storiesOf } from '@storybook/react'
       storiesOf('MyComponent', module)
     `,
+    `
+      const Primary = {}
+      const Secondary = {}
+      export default {}
+      export { Primary, Secondary }
+    `,
+    dedent`
+      export default {
+        excludeStories: /.*Data$/,
+      }
+
+      const mockData = {}
+      const Primary = {}
+
+      export { mockData, Primary }
+      `
   ],
   invalid: [
     {
@@ -67,6 +83,23 @@ ruleTester.run('story-exports', rule, {
 
       //   export const Default = {}
       // `,
+      errors: [
+        {
+          messageId: 'shouldHaveStoryExport',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        export default {
+          excludeStories: /.*Data$/,
+        }
+
+        const mockData = {}
+        const Primary = {}
+
+        export { mockData }
+      `,
       errors: [
         {
           messageId: 'shouldHaveStoryExport',


### PR DESCRIPTION
Issue: #57 

## What Changed

<!-- Insert a description below. Don't forget to run `yarn update-all` to update configuration files and their documentation! -->
Fixed a bug where the story-exports rule gave a false negative because it did not check for exports from an export list, only from inline export declarations.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
