### PR TITLE
fix: gracefully handle dynamic values in non-story exports configuration

### DIFF
--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -119,10 +119,12 @@ export = createStorybookRule({
       ExportDefaultDeclaration: function (node: any) {
         meta = getMetaObjectExpression(node, context)
         if (meta) {
-          nonStoryExportsConfig = {
-            excludeStories: getDescriptor(meta, 'excludeStories'),
-            includeStories: getDescriptor(meta, 'includeStories'),
-          }
+          try {
+            nonStoryExportsConfig = {
+              excludeStories: getDescriptor(meta, 'excludeStories'),
+              includeStories: getDescriptor(meta, 'includeStories'),
+            }
+          } catch (err) {}
         }
       },
       ExportNamedDeclaration: function (node: ExportNamedDeclaration) {

--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -59,10 +59,12 @@ export = createStorybookRule({
       ExportDefaultDeclaration: function (node) {
         meta = getMetaObjectExpression(node, context)
         if (meta) {
-          nonStoryExportsConfig = {
-            excludeStories: getDescriptor(meta, 'excludeStories'),
-            includeStories: getDescriptor(meta, 'includeStories'),
-          }
+          try {
+            nonStoryExportsConfig = {
+              excludeStories: getDescriptor(meta, 'excludeStories'),
+              includeStories: getDescriptor(meta, 'includeStories'),
+            }
+          } catch (err) {}
         }
       },
       ExportNamedDeclaration: function (node) {

--- a/tests/lib/rules/prefer-pascal-case.test.ts
+++ b/tests/lib/rules/prefer-pascal-case.test.ts
@@ -42,6 +42,15 @@ ruleTester.run('prefer-pascal-case', rule, {
       export const SimpleStory = () => <MyComponent data={simpleData} />;
       export const ComplexStory = () => <MyComponent data={complexData} />;
     `,
+    `
+      export default {
+        title: 'MyComponent',
+        component: MyComponent,
+        includeStories: [MyComponent.name],
+      };
+
+      export const SimpleStory = () => <MyComponent />;
+    `,
   ],
 
   invalid: [
@@ -101,10 +110,8 @@ ruleTester.run('prefer-pascal-case', rule, {
           includeStories: /.*Story$/,
           excludeStories: /.*Data$/,
         };
-
         export const simpleData = { foo: 1, bar: 'baz' };
         export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
-
         export const simpleStory = () => <MyComponent data={simpleData} />;
         simpleStory.args = {};
       `,
@@ -125,10 +132,8 @@ ruleTester.run('prefer-pascal-case', rule, {
                   includeStories: /.*Story$/,
                   excludeStories: /.*Data$/,
                 };
-
                 export const simpleData = { foo: 1, bar: 'baz' };
                 export const complexData = { foo: 1, foobar: { bar: 'baz', baz: someData } };
-
                 export const SimpleStory = () => <MyComponent data={simpleData} />;
                 SimpleStory.args = {};
               `,

--- a/tests/lib/rules/story-exports.test.ts
+++ b/tests/lib/rules/story-exports.test.ts
@@ -36,6 +36,15 @@ ruleTester.run('story-exports', rule, {
       export default {}
       export { Primary, Secondary }
     `,
+    `
+      export default {
+        title: 'MyComponent',
+        component: MyComponent,
+        includeStories: [MyComponent.name],
+      };
+
+      export const SimpleStory = () => <MyComponent />;
+    `,
     dedent`
       export default {
         excludeStories: /.*Data$/,


### PR DESCRIPTION
Issue: #65 

## What Changed

Rules that access the `includeStories`/`excludeStories` properties from Meta and throw an error (e.g. using dynamic properties) will be gracefully handled now.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
