### PR TITLE
no-redundant-story-name: use same naming algorithm as storybook

### DIFF
--- a/lib/rules/no-redundant-story-name.ts
+++ b/lib/rules/no-redundant-story-name.ts
@@ -3,6 +3,8 @@
  * @author Yann Braga
  */
 
+import { storyNameFromExport } from '@storybook/csf'
+
 import {
   isExpressionStatement,
   isLiteral,
@@ -39,21 +41,6 @@ export = createStorybookRule({
   },
 
   create(context: any) {
-    // variables should be defined here
-
-    //----------------------------------------------------------------------
-    // Helpers
-    //----------------------------------------------------------------------
-
-    //@TODO use the correct name resolver (equivalent to lodash.startcase used in @storybook/csf)
-    const resolveStoryName = (str: any) =>
-      str
-        .replace(/([A-Z]{1,})/g, ' $1')
-        .replace(/(^\w|\s\w)/g, (m: any) => m.toUpperCase())
-        .split(' ')
-        .filter(Boolean)
-        .join(' ')
-
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
@@ -80,7 +67,7 @@ export = createStorybookRule({
             }
 
             const { name } = id
-            const resolvedStoryName = resolveStoryName(name)
+            const resolvedStoryName = storyNameFromExport(name)
 
             //@ts-ignore
             if (isLiteral(storyNameNode.value) && storyNameNode.value.value === resolvedStoryName) {
@@ -108,7 +95,7 @@ export = createStorybookRule({
         if (isIdentifier(left.property) && left.property.name === 'storyName') {
           const propertyName = left.object.name
           const propertyValue = right.value
-          const resolvedStoryName = resolveStoryName(propertyName)
+          const resolvedStoryName = storyNameFromExport(propertyName)
 
           if (propertyValue === resolvedStoryName) {
             context.report({

--- a/tests/lib/rules/no-redundant-story-name.test.ts
+++ b/tests/lib/rules/no-redundant-story-name.test.ts
@@ -35,6 +35,12 @@ ruleTester.run('no-redundant-story-name', rule, {
       }
       PrimaryButton.storyName = 'The Primary Button'
     `,
+    `
+      export function H1 () {
+        return <h1>Hello</h1>
+      }
+      H1.storyName = 'H1'
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
Issue: #62 

## What Changed

Now the rule will use the same method that is used by Storybook to generate the story name.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
