### PR TITLE
Fix ast-utils import

### DIFF
--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -3,7 +3,7 @@
  * @author Yann Braga
  */
 
-import { findVariable } from '@typescript-eslint/experimental-utils/dist/ast-utils'
+import { ASTUtils } from '@typescript-eslint/experimental-utils'
 import { ExportNamedDeclaration } from '@typescript-eslint/types/dist/ast-spec'
 import { isExportStory } from '@storybook/csf'
 
@@ -86,7 +86,7 @@ export = createStorybookRule({
 
                 const scope = context.getScope().childScopes[0]
                 if (scope) {
-                  const variable = findVariable(scope, name)
+                  const variable = ASTUtils.findVariable(scope, name)
                   for (let i = 0; i < variable?.references?.length; i++) {
                     const ref = variable.references[i]
                     if (!ref.init) {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,6 +1,6 @@
 import { isExportStory } from '@storybook/csf'
 import { ExportDefaultDeclaration } from '@typescript-eslint/types/dist/ast-spec'
-import { findVariable } from '@typescript-eslint/experimental-utils/dist/ast-utils'
+import { ASTUtils } from '@typescript-eslint/experimental-utils'
 import {
   isFunctionDeclaration,
   isIdentifier,
@@ -21,7 +21,7 @@ export const isPlayFunction = (node: any) => {
 export const getMetaObjectExpression = (node: ExportDefaultDeclaration, context: any) => {
   let meta = node.declaration
   if (isIdentifier(meta)) {
-    const variable = findVariable(context.getScope(), meta.name)
+    const variable = ASTUtils.findVariable(context.getScope(), meta.name)
     const decl = variable && variable.defs.find((def) => isVariableDeclarator(def.node))
     if (decl && isVariableDeclarator(decl.node)) {
       meta = decl.node.init


### PR DESCRIPTION
Issue: #75

## What Changed

Changed the AST utils imports to use the public API so they'll work with both the old `@typescript-eslint/experimental-utils` and newly renamed `@typescript-eslint/utils` packages.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
