### PR TITLE
fix syntax of code example in docs: hierarchy-separator

### DIFF
--- a/docs/rules/hierarchy-separator.md
+++ b/docs/rules/hierarchy-separator.md
@@ -14,8 +14,8 @@ Examples of **incorrect** code for this rule:
 
 ```js
 export default {
-  title: 'Components|Forms/Input,
-  component: Input
+  title: 'Components|Forms/Input',
+  component: Input,
 }
 ```
 
@@ -23,8 +23,8 @@ Examples of **correct** code for this rule:
 
 ```js
 export default {
-  title: 'Components/Forms/Input,
-  component: Input
+  title: 'Components/Forms/Input',
+  component: Input,
 }
 ```
 


### PR DESCRIPTION
Issue: #

## What Changed

- add a closing quote on string of code example in docs
- run `yar update-all` which added a trailing comma on the same code example

## Checklist

Check the ones applicable to your change:

- [X] Ran `yarn update-all`
- [ ] Tests are updated
- [X] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [X] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
