### PR TITLE
fix: add optional chaining to object property key

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,6 @@ yarn update-all
 
 ### Useful resources
 
-- The [ESLint official developer](https://eslint.org/docs/developer-guide/working-with-rules) can be useful to assist when writing rules
+- The [ESLint official developer guide](https://eslint.org/docs/developer-guide/working-with-rules) can be useful to assist when writing rules
 - The [AST Explorer](https://astexplorer.net/) website is the perfect place to get reference to writing rules. Given that ESLint rules are based in AST (Abstract Syntax Tree), you can paste an example code there and visualize all properties of the resulting AST of that code.
 - Storybook has a discord community! And we need more people like you. Please [join us](https://discord.gg/storybook) and say hi in the #contributors channel! 👋

--- a/lib/rules/csf-component.ts
+++ b/lib/rules/csf-component.ts
@@ -49,7 +49,7 @@ export = createStorybookRule({
         }
 
         const componentProperty = meta.properties.find(
-          (property: any) => property.key.name === 'component'
+          (property: any) => property.key?.name === 'component'
         )
         if (!componentProperty) {
           context.report({

--- a/lib/rules/hierarchy-separator.ts
+++ b/lib/rules/hierarchy-separator.ts
@@ -39,7 +39,7 @@ export = createStorybookRule({
           return null
         }
 
-        const titleNode = meta.properties.find((prop: any) => prop.key.name === 'title')
+        const titleNode = meta.properties.find((prop: any) => prop.key?.name === 'title')
 
         //@ts-ignore
         if (!titleNode || !isLiteral(titleNode.value)) {

--- a/lib/rules/meta-inline-properties.ts
+++ b/lib/rules/meta-inline-properties.ts
@@ -73,7 +73,7 @@ export = createStorybookRule({
 
         const metaNodes = meta.properties.filter((prop: any) =>
           //@ts-ignore
-          ruleProperties.includes(prop.key.name)
+          ruleProperties.includes(prop.key?.name)
         )
 
         metaNodes.forEach((metaNode: any) => {
@@ -89,7 +89,7 @@ export = createStorybookRule({
               node: propertyNode,
               messageId: 'metaShouldHaveInlineProperties',
               data: {
-                property: propertyNode.key.name,
+                property: propertyNode.key?.name,
               },
             })
           })

--- a/lib/rules/no-title-property-in-meta.ts
+++ b/lib/rules/no-title-property-in-meta.ts
@@ -37,7 +37,7 @@ export = createStorybookRule({
           return null
         }
 
-        const titleNode = meta.properties.find((prop: any) => prop.key.name === 'title')
+        const titleNode = meta.properties.find((prop: any) => prop.key?.name === 'title')
 
         if (titleNode) {
           context.report({

--- a/tests/lib/rules/hierarchy-separator.test.ts
+++ b/tests/lib/rules/hierarchy-separator.test.ts
@@ -19,9 +19,11 @@ import ruleTester from '../../utils/rule-tester'
 
 ruleTester.run('hierarchy-separator', rule, {
   valid: [
+    "export default {  }",
     "export default { title: 'Examples.Components' }",
     "export default { title: 'Examples/Components/Button' }",
     "export default { title: 'Examples/Components/Button' } as ComponentMeta<typeof Button>",
+    "export default { ...props } as ComponentMeta<typeof Button>",
   ],
 
   invalid: [

--- a/tests/lib/rules/no-title-property-in-meta.test.ts
+++ b/tests/lib/rules/no-title-property-in-meta.test.ts
@@ -19,8 +19,10 @@ import ruleTester from '../../utils/rule-tester'
 
 ruleTester.run('no-title-property-in-meta', rule, {
   valid: [
+    "export default {  }",
     'export default { component: Button }',
     'export default { component: Button } as ComponentMeta<typeof Button>',
+    "export default { ...props }",
   ],
 
   invalid: [


### PR DESCRIPTION
Issue: #78

## What Changed

- add optional chaining to the handling of `MetaObjectExpression` properties to prevent type exception when not of type `Property`.
- add a few test cases to help validate more syntactically valid cases
- minor text update to CONTRIBUTING.md

## Checklist

Check the ones applicable to your change:

- [X] Ran `yarn update-all`
- [X] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
