### PR TITLE
chore: remove release label restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "plugins": [
       "npm",
       "released"
-    ],
-    "onlyPublishWithReleaseLabel": true
+    ]
   }
 }


### PR DESCRIPTION
Issue: N/A

## What Changed

<!-- Insert a description below. Don't forget to run `yarn update-all` to update configuration files and their documentation! -->

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [x] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.7--canary.82.b92f058.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-plugin-storybook@0.5.7--canary.82.b92f058.0
  # or 
  yarn add eslint-plugin-storybook@0.5.7--canary.82.b92f058.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
