### PR TITLE
fix: support ChainExpression in await-interactions rule

### DIFF
--- a/lib/rules/await-interactions.ts
+++ b/lib/rules/await-interactions.ts
@@ -141,7 +141,7 @@ export = createStorybookRule({
     return {
       CallExpression(node: CallExpression) {
         const method = getMethodThatShouldBeAwaited(node)
-        if (method && !isAwaitExpression(node.parent)) {
+        if (method && !isAwaitExpression(node.parent) && !isAwaitExpression(node.parent.parent)) {
           invocationsThatShouldBeAwaited.push({ node, method })
         }
       },

--- a/lib/rules/await-interactions.ts
+++ b/lib/rules/await-interactions.ts
@@ -141,7 +141,7 @@ export = createStorybookRule({
     return {
       CallExpression(node: CallExpression) {
         const method = getMethodThatShouldBeAwaited(node)
-        if (method && !isAwaitExpression(node.parent) && !isAwaitExpression(node.parent.parent)) {
+        if (method && !isAwaitExpression(node.parent) && !isAwaitExpression(node.parent?.parent)) {
           invocationsThatShouldBeAwaited.push({ node, method })
         }
       },

--- a/tests/lib/rules/await-interactions.test.ts
+++ b/tests/lib/rules/await-interactions.test.ts
@@ -80,6 +80,27 @@ ruleTester.run('await-interactions', rule, {
     // `,
     'Basic.play = async () => userEvent.click(button)',
     'Basic.play = async () => { return userEvent.click(button) }',
+    dedent`
+      export const SecondStory = {
+        play: async (context) => {
+          await FirstStory.play(context)
+        }
+      }
+    `,
+    dedent`
+      export const SecondStory = {
+        play: async (context) => {
+          await FirstStory.play?.(context)
+        }
+      }
+    `,
+    dedent`
+      export const SecondStory = {
+        play: async (context) => {
+          await FirstStory.play!(context)
+        }
+      }
+    `,
   ],
   invalid: [
     {
@@ -292,22 +313,28 @@ ruleTester.run('await-interactions', rule, {
     },
     {
       code: dedent`
-        export const ThirdStory = {
+        export const FourthStory = {
           play: async (context) => {
             FirstStory.play(context)
             SecondStory.play!(context)
+            ThirdStory.play?.(context)
           }
         }
       `,
       output: dedent`
-        export const ThirdStory = {
+        export const FourthStory = {
           play: async (context) => {
             await FirstStory.play(context)
             await SecondStory.play!(context)
+            await ThirdStory.play?.(context)
           }
         }
       `,
       errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'play' },
+        },
         {
           messageId: 'interactionShouldBeAwaited',
           data: { method: 'play' },


### PR DESCRIPTION
Issue: #86

## What Changed

in existing use-cases of the `await-interactions` rule, the code is assumed to be valid when the `CallExpression` node is the immediate child of an `AwaitExpression` node.

> `await FirstStory.play(context);` → AwaitExpression > CallExpression > …

> `await FirstStory.play!(context);` → AwaitExpression > CallExpression > TSNonNullExpression > …

to support an expression with an optional chain, the logic to determine if the expression was properly awaited now checks if the _parent of the parent_ of the `CallExpression` node is an `AwaitExpression`.

> `await FirstStory.play?.(context);` → AwaitExpression > ChainExpression > CallExpression > …

## Checklist

Check the ones applicable to your change:

- [x] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
