### PR TITLE
Increase type safety

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
     {
       files: ['tests/**/*.js'],
       rules: {
-        'node/no-unpublished-require': 'off'
+        'node/no-unpublished-require': 'off',
       },
       env: { mocha: true },
     },

--- a/lib/rules/context-in-play-function.ts
+++ b/lib/rules/context-in-play-function.ts
@@ -32,7 +32,7 @@ export = createStorybookRule({
     messages: {
       passContextToPlayFunction: 'Pass a context when invoking play function of another story',
     },
-    fixable: null,
+    fixable: undefined,
     schema: [],
   },
 

--- a/lib/rules/csf-component.ts
+++ b/lib/rules/csf-component.ts
@@ -3,10 +3,11 @@
  * @author Yann Braga
  */
 
-import { ExportDefaultDeclaration, Node } from '@typescript-eslint/types/dist/ast-spec'
+import { ExportDefaultDeclaration } from '@typescript-eslint/types/dist/ast-spec'
 import { getMetaObjectExpression } from '../utils'
 import { CategoryId } from '../utils/constants'
 import { createStorybookRule } from '../utils/create-storybook-rule'
+import { isSpreadElement } from '../utils/ast'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -28,7 +29,7 @@ export = createStorybookRule({
     schema: [],
   },
 
-  create(context: any) {
+  create(context) {
     // variables should be defined here
 
     //----------------------------------------------------------------------
@@ -44,13 +45,18 @@ export = createStorybookRule({
     return {
       ExportDefaultDeclaration(node: ExportDefaultDeclaration) {
         const meta = getMetaObjectExpression(node, context)
+
         if (!meta) {
           return null
         }
 
         const componentProperty = meta.properties.find(
-          (property: any) => property.key?.name === 'component'
+          (property) =>
+            !isSpreadElement(property) &&
+            'name' in property.key &&
+            property.key.name === 'component'
         )
+
         if (!componentProperty) {
           context.report({
             node,

--- a/lib/rules/no-stories-of.ts
+++ b/lib/rules/no-stories-of.ts
@@ -26,7 +26,7 @@ export = createStorybookRule({
     schema: [],
   },
 
-  create(context: any) {
+  create(context) {
     // variables should be defined here
 
     //----------------------------------------------------------------------
@@ -40,7 +40,7 @@ export = createStorybookRule({
     //----------------------------------------------------------------------
 
     return {
-      ImportSpecifier(node: any) {
+      ImportSpecifier(node) {
         if (node.imported.name === 'storiesOf') {
           context.report({
             node,

--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -81,9 +81,9 @@ export = createStorybookRule({
                 const scope = context.getScope().childScopes[0]
                 if (scope) {
                   const variable = ASTUtils.findVariable(scope, name)
-                  const index = variable?.references?.length || 0
+                  const referenceCount = variable?.references?.length || 0
 
-                  for (let i = 0; i < index; i++) {
+                  for (let i = 0; i < referenceCount; i++) {
                     const ref = variable!.references[i]
                     if (!ref.init) {
                       yield fixer.replaceTextRange(ref.identifier.range, pascal)

--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -14,6 +14,8 @@ import {
   isValidStoryExport,
 } from '../utils'
 import { isImportDeclaration } from '../utils/ast'
+import { IncludeExcludeOptions } from '@storybook/csf'
+import { ObjectExpression, Identifier } from '@typescript-eslint/types/dist/ast-spec'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -33,7 +35,7 @@ export = createStorybookRule({
       shouldHaveStoryExport: 'The file should have at least one story export',
       addStoryExport: 'Add a story export',
     },
-    fixable: null, // change to 'code' once we have autofixes
+    fixable: undefined, // change to 'code' once we have autofixes
     schema: [],
   },
 
@@ -49,9 +51,9 @@ export = createStorybookRule({
     //----------------------------------------------------------------------
 
     let hasStoriesOfImport = false
-    let nonStoryExportsConfig = {}
-    let meta
-    let namedExports = []
+    let nonStoryExportsConfig: IncludeExcludeOptions = {}
+    let meta: ObjectExpression | null
+    let namedExports: Identifier[] = []
 
     return {
       ImportSpecifier(node) {

--- a/lib/rules/use-storybook-expect.ts
+++ b/lib/rules/use-storybook-expect.ts
@@ -19,7 +19,7 @@ type TDefaultOptions = {
 
 export = createStorybookRule<TDefaultOptions, string>({
   name: 'use-storybook-expect',
-  defaultOptions: [{ storybookJestPath: '@storybook/jest' }],
+  defaultOptions: [],
   meta: {
     type: 'suggestion',
     fixable: 'code',

--- a/lib/rules/use-storybook-expect.ts
+++ b/lib/rules/use-storybook-expect.ts
@@ -4,23 +4,22 @@
  */
 
 import { CategoryId } from '../utils/constants'
-import {
-  isExpressionStatement,
-  isCallExpression,
-  isMemberExpression,
-  isIdentifier,
-  isBlockStatement,
-} from '../utils/ast'
+import { isIdentifier, isImportSpecifier } from '../utils/ast'
 
 import { createStorybookRule } from '../utils/create-storybook-rule'
+import { ImportDeclaration, Identifier } from '@typescript-eslint/types/dist/ast-spec'
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-export = createStorybookRule({
+type TDefaultOptions = {
+  storybookJestPath?: string
+}[]
+
+export = createStorybookRule<TDefaultOptions, string>({
   name: 'use-storybook-expect',
-  defaultOptions: [],
+  defaultOptions: [{ storybookJestPath: '@storybook/jest' }],
   meta: {
     type: 'suggestion',
     fixable: 'code',
@@ -38,57 +37,29 @@ export = createStorybookRule({
     },
   },
 
-  create(context: any) {
+  create(context) {
     // variables should be defined here
 
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------
 
-    const getExpressionStatements = (body = []) => {
-      return body.filter((b) => isExpressionStatement(b))
-    }
-
-    //@ts-ignore
-    const isExpect = (expression) => {
-      return (
-        isCallExpression(expression) &&
-        isMemberExpression(expression.callee) &&
-        isCallExpression(expression.callee.object) &&
-        isIdentifier(expression.callee.object.callee) &&
-        expression.callee.object.callee.name === 'expect'
-      )
-    }
-
-    const isExpectFromStorybookImported = (node: any) => {
+    const isExpectFromStorybookImported = (node: ImportDeclaration) => {
       return (
         node.source.value === '@storybook/jest' &&
-        node.specifiers.find((spec: any) => spec.imported.name === 'expect')
+        node.specifiers.find((spec) => isImportSpecifier(spec) && spec.imported.name === 'expect')
       )
     }
 
-    const checkExpectInvocations = (blockStatement) => {
-      if (!isBlockStatement(blockStatement)) {
-        return
-      }
-
-      const expressionBody = blockStatement.body || []
-      const expressionStatements = getExpressionStatements(expressionBody)
-      expressionStatements.forEach(({ expression }) => {
-        if (isExpect(expression)) {
-          expectInvocations.push(expression)
-        }
-      })
-    }
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
 
     let isImportingFromStorybookExpect = false
-    let expectInvocations: any = []
+    let expectInvocations: Identifier[] = []
 
     return {
-      ImportDeclaration(node: any) {
+      ImportDeclaration(node) {
         if (isExpectFromStorybookImported(node)) {
           isImportingFromStorybookExpect = true
         }
@@ -104,12 +75,11 @@ export = createStorybookRule({
       },
       'Program:exit': function () {
         if (!isImportingFromStorybookExpect && expectInvocations.length) {
-          //@ts-ignore
           expectInvocations.forEach((node) => {
             context.report({
               node,
               messageId: 'useExpectFromStorybook',
-              fix: function (fixer: any) {
+              fix: function (fixer) {
                 return fixer.insertTextAfterRange(
                   [0, 0],
                   "import { expect } from '@storybook/jest';\n"
@@ -118,7 +88,7 @@ export = createStorybookRule({
               suggest: [
                 {
                   messageId: 'updateImports',
-                  fix: function (fixer: any) {
+                  fix: function (fixer) {
                     return fixer.insertTextAfterRange(
                       [0, 0],
                       "import { expect } from '@storybook/jest';\n"

--- a/lib/rules/use-storybook-testing-library.ts
+++ b/lib/rules/use-storybook-testing-library.ts
@@ -3,6 +3,12 @@
  * @author Yann Braga
  */
 
+import {
+  Range,
+  StringLiteral,
+  ImportDeclaration,
+  ImportClause,
+} from '@typescript-eslint/types/dist/ast-spec'
 import { isImportDefaultSpecifier } from '../utils/ast'
 import { CategoryId } from '../utils/constants'
 import { createStorybookRule } from '../utils/create-storybook-rule'
@@ -30,13 +36,13 @@ export = createStorybookRule({
     },
   },
 
-  create(context: any) {
+  create(context) {
     // variables should be defined here
 
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------
-    const getRangeWithoutQuotes = (source) => {
+    const getRangeWithoutQuotes = (source: StringLiteral): Range => {
       return [
         // Not sure how to improve this. If I use node.source.range
         // it will eat the quotes and we do not want to specify whether the quotes are single or double
@@ -45,9 +51,10 @@ export = createStorybookRule({
       ]
     }
 
-    const hasDefaultImport = (specifiers) => specifiers.find((s) => isImportDefaultSpecifier(s))
+    const hasDefaultImport = (specifiers: ImportClause[]) =>
+      specifiers.find((s) => isImportDefaultSpecifier(s))
 
-    const getSpecifiers = (node) => {
+    const getSpecifiers = (node: ImportDeclaration) => {
       const { specifiers } = node
 
       const start = specifiers[0].range[0]
@@ -66,10 +73,10 @@ export = createStorybookRule({
       }
       const text = fullText.substring(start, end)
 
-      return { range: [start, end], text }
+      return { range: [start, end] as Range, text }
     }
 
-    const fixSpecifiers = (specifiersText) => {
+    const fixSpecifiers = (specifiersText: string) => {
       const flattened = specifiersText
         .replace('{', '')
         .replace('}', '')
@@ -83,7 +90,7 @@ export = createStorybookRule({
     //----------------------------------------------------------------------
 
     return {
-      ImportDeclaration(node: any) {
+      ImportDeclaration(node) {
         if (node.source.value.includes('@testing-library')) {
           context.report({
             node,

--- a/lib/utils/ast.ts
+++ b/lib/utils/ast.ts
@@ -38,3 +38,4 @@ export const isTSTypeAliasDeclaration = isNodeOfType(AST_NODE_TYPES.TSTypeAliasD
 export const isTSInterfaceDeclaration = isNodeOfType(AST_NODE_TYPES.TSInterfaceDeclaration)
 export const isTSAsExpression = isNodeOfType(AST_NODE_TYPES.TSAsExpression)
 export const isTSNonNullExpression = isNodeOfType(AST_NODE_TYPES.TSNonNullExpression)
+export const isMetaProperty = isNodeOfType(AST_NODE_TYPES.MetaProperty)

--- a/lib/utils/create-storybook-rule.ts
+++ b/lib/utils/create-storybook-rule.ts
@@ -2,10 +2,12 @@ import { ESLintUtils } from '@typescript-eslint/experimental-utils'
 
 import { docsUrl } from '../utils'
 import { StorybookRuleMeta } from '../types'
+import { RuleContext, RuleListener } from '@typescript-eslint/experimental-utils/dist/ts-eslint'
 
 export function createStorybookRule<
   TOptions extends readonly unknown[],
-  TMessageIds extends string
+  TMessageIds extends string,
+  TRuleListener extends RuleListener = RuleListener
 >({
   create,
   meta,
@@ -14,7 +16,10 @@ export function createStorybookRule<
   name: string
   meta: StorybookRuleMeta<TMessageIds, TOptions>
   defaultOptions: Readonly<TOptions>
-  create: any
+  create: (
+    context: Readonly<RuleContext<TMessageIds, TOptions>>,
+    optionsWithDefault: Readonly<TOptions>
+  ) => TRuleListener
 }>) {
   return ESLintUtils.RuleCreator(docsUrl)({
     ...remainingConfig,

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,25 +1,30 @@
-import { isExportStory } from '@storybook/csf'
-import { ExportDefaultDeclaration } from '@typescript-eslint/types/dist/ast-spec'
+import { IncludeExcludeOptions, isExportStory } from '@storybook/csf'
+import {
+  ExportDefaultDeclaration,
+  ExportNamedDeclaration,
+  Identifier,
+  ObjectExpression,
+} from '@typescript-eslint/types/dist/ast-spec'
 import { ASTUtils } from '@typescript-eslint/experimental-utils'
 import {
   isFunctionDeclaration,
   isIdentifier,
   isObjectExpression,
+  isSpreadElement,
   isTSAsExpression,
   isVariableDeclaration,
   isVariableDeclarator,
 } from './ast'
+import { RuleContext } from '@typescript-eslint/experimental-utils/dist/ts-eslint'
 
-export const docsUrl = (ruleName: any) =>
+export const docsUrl = (ruleName: string) =>
   `https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/${ruleName}.md`
 
-export const isPlayFunction = (node: any) => {
-  const propertyName = node.left && node.left.property && node.left.property.name
-  return propertyName === 'play'
-}
-
-export const getMetaObjectExpression = (node: ExportDefaultDeclaration, context: any) => {
-  let meta = node.declaration
+export const getMetaObjectExpression = (
+  node: ExportDefaultDeclaration,
+  context: Readonly<RuleContext<string, readonly unknown[]>>
+) => {
+  let meta: ExportDefaultDeclaration['declaration'] | null = node.declaration
   if (isIdentifier(meta)) {
     const variable = ASTUtils.findVariable(context.getScope(), meta.name)
     const decl = variable && variable.defs.find((def) => isVariableDeclarator(def.node))
@@ -34,10 +39,17 @@ export const getMetaObjectExpression = (node: ExportDefaultDeclaration, context:
   return isObjectExpression(meta) ? meta : null
 }
 
-export const getDescriptor = (metaDeclaration, propertyName) => {
+export const getDescriptor = (
+  metaDeclaration: ObjectExpression,
+  propertyName: string
+): string[] | RegExp | undefined => {
   const property =
-    metaDeclaration && metaDeclaration.properties.find((p) => p.key && p.key.name === propertyName)
-  if (!property) {
+    metaDeclaration &&
+    metaDeclaration.properties.find(
+      (p) => 'key' in p && 'name' in p.key && p.key.name === propertyName
+    )
+
+  if (!property || isSpreadElement(property)) {
     return undefined
   }
 
@@ -49,20 +61,26 @@ export const getDescriptor = (metaDeclaration, propertyName) => {
         if (!['StringLiteral', 'Literal'].includes(t.type)) {
           throw new Error(`Unexpected descriptor element: ${t.type}`)
         }
+        // @ts-ignore
         return t.value
       })
     case 'Literal':
+    // TODO: Investigation needed. Type systems says, that "RegExpLiteral" does not exist
+    // @ts-ignore
     case 'RegExpLiteral':
+      // @ts-ignore
       return property.value.value
     default:
       throw new Error(`Unexpected descriptor: ${type}`)
   }
 }
 
-export const isValidStoryExport = (node, nonStoryExportsConfig) =>
-  isExportStory(node.name, nonStoryExportsConfig) && node.name !== '__namedExportsOrder'
+export const isValidStoryExport = (
+  node: Identifier,
+  nonStoryExportsConfig: IncludeExcludeOptions
+) => isExportStory(node.name, nonStoryExportsConfig) && node.name !== '__namedExportsOrder'
 
-export const getAllNamedExports = (node) => {
+export const getAllNamedExports = (node: ExportNamedDeclaration) => {
   // e.g. `export { MyStory }`
   if (!node.declaration && node.specifiers) {
     return node.specifiers.reduce((acc, specifier) => {
@@ -70,7 +88,7 @@ export const getAllNamedExports = (node) => {
         acc.push(specifier.exported)
       }
       return acc
-    }, [])
+    }, [] as Identifier[])
   }
 
   const decl = node.declaration

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/eslint": "^7.28.2",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.6",
+    "@types/requireindex": "^1.2.0",
     "@typescript-eslint/parser": "^5.3.0",
     "auto": "^10.32.2",
     "eslint": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build": "tsc",
     "start": "tsc --watch",
     "test": "jest",
-    "test:ci": "jest --ci",
+    "test:ci": "tsc --noEmit && jest --ci",
     "generate-rule": "ts-node ./tools/generate-rule",
     "update-configs": "ts-node ./tools/update-configs",
     "update-docs": "ts-node ./tools/update-rules-list",

--- a/tests/lib/rules/hierarchy-separator.test.ts
+++ b/tests/lib/rules/hierarchy-separator.test.ts
@@ -19,11 +19,11 @@ import ruleTester from '../../utils/rule-tester'
 
 ruleTester.run('hierarchy-separator', rule, {
   valid: [
-    "export default {  }",
+    'export default {  }',
     "export default { title: 'Examples.Components' }",
     "export default { title: 'Examples/Components/Button' }",
     "export default { title: 'Examples/Components/Button' } as ComponentMeta<typeof Button>",
-    "export default { ...props } as ComponentMeta<typeof Button>",
+    'export default { ...props } as ComponentMeta<typeof Button>',
   ],
 
   invalid: [

--- a/tests/lib/rules/no-title-property-in-meta.test.ts
+++ b/tests/lib/rules/no-title-property-in-meta.test.ts
@@ -19,10 +19,10 @@ import ruleTester from '../../utils/rule-tester'
 
 ruleTester.run('no-title-property-in-meta', rule, {
   valid: [
-    "export default {  }",
+    'export default {  }',
     'export default { component: Button }',
     'export default { component: Button } as ComponentMeta<typeof Button>',
-    "export default { ...props }",
+    'export default { ...props }',
   ],
 
   invalid: [

--- a/tools/update-configs.ts
+++ b/tools/update-configs.ts
@@ -4,10 +4,10 @@ This script updates `lib/configs/*.js` files from rule's meta data.
 
 import fs from 'fs'
 import path from 'path'
-import { format } from 'prettier'
+import { format, Options } from 'prettier'
 import prettierConfig from '../.prettierrc'
 
-import { categories } from './utils/categories'
+import { categories, TCategory } from './utils/categories'
 
 const extendsCategories = {
   csf: null,
@@ -19,9 +19,9 @@ const externalRuleOverrides = {
   'import/no-anonymous-default-export': 'off',
 }
 
-function formatRules(rules: any) {
+function formatRules(rules: TCategory['rules']) {
   const obj = rules.reduce(
-    (setting: any, rule: any) => {
+    (setting, rule) => {
       setting[rule.ruleId] = rule.meta.docs.recommended || 'error'
       return setting
     },
@@ -37,7 +37,7 @@ const STORIES_GLOBS = [
   `'*.story.@(${SUPPORTED_EXTENSIONS.join('|')})'`,
 ]
 
-function formatCategory(category: any) {
+function formatCategory(category: TCategory) {
   const extendsCategoryId = extendsCategories[category.categoryId]
   if (extendsCategoryId == null) {
     return `/*
@@ -77,10 +77,9 @@ fs.mkdirSync(ROOT)
 // Update/add rule files
 categories.forEach((category) => {
   const filePath = path.join(ROOT, `${category.categoryId}.ts`)
-  //@ts-ignore
   const content = format(formatCategory(category), {
     parser: 'typescript',
-    ...prettierConfig,
+    ...prettierConfig as Options,
   })
 
   fs.writeFileSync(filePath, content)

--- a/tools/update-configs.ts
+++ b/tools/update-configs.ts
@@ -79,7 +79,7 @@ categories.forEach((category) => {
   const filePath = path.join(ROOT, `${category.categoryId}.ts`)
   const content = format(formatCategory(category), {
     parser: 'typescript',
-    ...prettierConfig as Options,
+    ...(prettierConfig as Options),
   })
 
   fs.writeFileSync(filePath, content)

--- a/tools/update-rules-list.ts
+++ b/tools/update-rules-list.ts
@@ -1,21 +1,26 @@
 import rules from './utils/rules'
 
-import { configBadges, emojiKey, writeRulesListInReadme, updateRulesDocs } from './utils/docs'
+import { emojiKey, writeRulesListInReadme, updateRulesDocs } from './utils/docs'
 
 /*
 This script updates the rules table in `README.md`from rule's meta data.
 */
 
+export type TRulesList = readonly [
+  ruleName: string,
+  ruleLink: string,
+  docsDescription: string,
+  fixable: string,
+  categories: string
+]
+export type TRuleListWithoutName = TRulesList extends readonly [string, ...infer TRulesWithoutName]
+  ? TRulesWithoutName
+  : never
+
 const createRuleLink = (ruleName: string) =>
   `[\`storybook/${ruleName}\`](./docs/rules/${ruleName}.md)`
 
-const generateConfigBadges = (recommendedConfig: any) =>
-  Object.entries(recommendedConfig)
-    .filter(([_, config]) => Boolean(config))
-    .map(([framework]) => configBadges[framework])
-    .join(' ')
-
-const rulesList = Object.entries(rules)
+const rulesList: TRulesList[] = Object.entries(rules)
   .sort(([_, { name: ruleNameA }], [__, { name: ruleNameB }]) => {
     return ruleNameA.localeCompare(ruleNameB)
   })

--- a/tools/utils/categories.ts
+++ b/tools/utils/categories.ts
@@ -1,7 +1,9 @@
-import rules from './rules'
+import rules, { TRules } from './rules'
 import { CategoryId } from '../../lib/utils/constants'
 
-const categoriesConfig = {
+type TCategoriesConfig = Record<string, { text: string; rules?: TRules }>
+
+const categoriesConfig: TCategoriesConfig = {
   [CategoryId.CSF]: {
     text: 'CSF Rules',
   },
@@ -45,9 +47,11 @@ export const categories = categoryIds
     return {
       categoryId,
       title: categoriesConfig[categoryId],
-      rules: categoriesConfig[categoryId].rules.filter((rule: any) => !rule.meta.deprecated),
+      rules: categoriesConfig[categoryId].rules.filter((rule) => !rule.meta.deprecated),
     }
   })
   .filter((category) => {
     return category.rules.length >= 1
   })
+
+export type TCategory = typeof categories extends (infer TCat)[] ? TCat : never

--- a/tools/utils/docs.ts
+++ b/tools/utils/docs.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
 
 import { format, resolveConfig } from 'prettier'
+import { TRulesList, TRuleListWithoutName } from '../update-rules-list'
 
 import { categoryIds } from './categories'
 
@@ -37,17 +38,18 @@ const staticElements = {
   ].join('\n'),
 }
 
-const generateRulesListTable = (rulesList: any) =>
+const generateRulesListTable = (rulesList: TRuleListWithoutName[]) =>
   [staticElements.listHeaderRow, staticElements.listSpacerRow, ...rulesList]
     .map((column) => `|${column.join('|')}|`)
     .join('\n')
 
-const generateRulesListMarkdown = (rulesList: any) =>
+const generateRulesListMarkdown = (rulesList: TRuleListWithoutName[]) =>
   ['', staticElements.rulesListKey, '', generateRulesListTable(rulesList), ''].join('\n')
 
 const listBeginMarker = '<!-- RULES-LIST:START -->'
 const listEndMarker = '<!-- RULES-LIST:END -->'
-const overWriteRulesList = (rulesList: any, readme: string) => {
+
+const overWriteRulesList = (rulesList: TRuleListWithoutName[], readme: string) => {
   const listStartIndex = readme.indexOf(listBeginMarker)
   const listEndIndex = readme.indexOf(listEndMarker)
 
@@ -66,7 +68,8 @@ const overWriteRulesList = (rulesList: any, readme: string) => {
 
 const ruleCategoriesBeginMarker = '<!-- RULE-CATEGORIES:START -->'
 const ruleCategoriesEndMarker = '<!-- RULE-CATEGORIES:END -->'
-const overWriteRuleDocs = (rule: any, ruleDocFile: string) => {
+
+const overWriteRuleDocs = (rule: TRulesList, ruleDocFile: string) => {
   const ruleCategoriesStartIndex = ruleDocFile.indexOf(ruleCategoriesBeginMarker)
   const ruleCategoriesEndIndex = ruleDocFile.indexOf(ruleCategoriesEndMarker)
 
@@ -83,9 +86,9 @@ const overWriteRuleDocs = (rule: any, ruleDocFile: string) => {
   ].join('\n')
 }
 
-export const writeRulesListInReadme = (rulesList: any) => {
+export const writeRulesListInReadme = (rulesList: TRulesList[]) => {
   const readme = readFileSync(readmePath, 'utf8')
-  const rulesListWithoutName = rulesList.map((rule) => rule.slice(1))
+  const rulesListWithoutName = rulesList.map((rule) => rule.slice(1)) as TRuleListWithoutName[]
   const newReadme = format(overWriteRulesList(rulesListWithoutName, readme), {
     parser: 'markdown',
     ...prettierConfig,
@@ -94,7 +97,7 @@ export const writeRulesListInReadme = (rulesList: any) => {
   writeFileSync(readmePath, newReadme)
 }
 
-export const updateRulesDocs = (rulesList: any) => {
+export const updateRulesDocs = (rulesList: TRulesList[]) => {
   rulesList.forEach((rule) => {
     const ruleName = rule[0]
     const ruleDocFilePath = resolve(ruleDocsPath, `${ruleName}.md`)

--- a/tools/utils/rules.ts
+++ b/tools/utils/rules.ts
@@ -1,14 +1,27 @@
 import fs from 'fs'
 import path from 'path'
 
+import { createStorybookRule } from '../../lib/utils/create-storybook-rule'
+
 const ROOT = path.resolve(__dirname, '../../lib/rules')
+
+export type TRule = ReturnType<typeof createStorybookRule> & {
+  meta: {
+    docs: {
+      categories?: string[]
+      category?: string
+      excludeFromConfig?: boolean
+    }
+  }
+}
 
 const rules = fs
   .readdirSync(ROOT)
   .filter((file) => path.extname(file) === '.ts')
   .map((file) => path.basename(file, '.ts'))
   .map((name) => {
-    const meta = { ...require(path.join(ROOT, name)).meta }
+    const rule = require(path.join(ROOT, name)) as TRule
+    const meta = { ...rule.meta }
     if (meta.docs && !meta.docs.categories) {
       meta.docs = { ...meta.docs }
       meta.docs.categories = []
@@ -29,6 +42,8 @@ const rules = fs
     }
   })
   // We might have rules which are almost ready but should not be shipped
-  .filter((rule: any) => !rule.meta.docs.excludeFromConfig)
+  .filter((rule) => !rule.meta.docs.excludeFromConfig)
+
+export type TRules = typeof rules
 
 export default rules

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,9 @@
     "strict": true,
     "skipLibCheck": true
   },
+  "ts-node": {
+    "transpileOnly": true
+  },
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaFeatures": { "jsx": true },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true
   },
   "parser": "@typescript-eslint/parser",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1628,6 +1628,11 @@
   resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"
   integrity sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==
 
+"@types/requireindex@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/requireindex/-/requireindex-1.2.0.tgz#b31ed3719fe0a5824fef9a3165f7743560d26bd5"
+  integrity sha512-XgAXuN2bI/w2kAN6jwhb5jrrSznOsded+Fz5YC+3Vs3f8UyE3d8FnTvIWe6shZdpz9NMHY/wtEWk17yL0hCSmg==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"


### PR DESCRIPTION
## What Changed

Added some types and removed obsolete "any" type assertions by replacing them through stronger types

## Change Type

Indicate the type of change your pull request is:

- [x] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.11--canary.89.28723b8.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-plugin-storybook@0.5.11--canary.89.28723b8.0
  # or 
  yarn add eslint-plugin-storybook@0.5.11--canary.89.28723b8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
