### PR TITLE
feat(default-exports): add autofix even if component name is not found

### DIFF
--- a/lib/rules/default-exports.ts
+++ b/lib/rules/default-exports.ts
@@ -86,23 +86,23 @@ export = createStorybookRule({
             messageId: 'shouldHaveDefaultExport',
           }
 
-          if (!componentName) {
-            context.report(report)
-          } else {
-            const fix = (fixer) =>
-              fixer.insertTextBefore(node, `export default { component: ${componentName} }\n`)
-
-            context.report({
-              ...report,
-              fix,
-              suggest: [
-                {
-                  messageId: 'fixSuggestion',
-                  fix,
-                },
-              ],
-            })
+          const fix = (fixer) => {
+            const metaDeclaration = componentName
+              ? `export default { component: ${componentName} }\n`
+              : 'export default {}\n'
+            return fixer.insertTextBefore(node, metaDeclaration)
           }
+
+          context.report({
+            ...report,
+            fix,
+            suggest: [
+              {
+                messageId: 'fixSuggestion',
+                fix,
+              },
+            ],
+          })
         }
       },
     }

--- a/tests/lib/rules/default-exports.test.ts
+++ b/tests/lib/rules/default-exports.test.ts
@@ -19,6 +19,7 @@ import ruleTester from '../../utils/rule-tester'
 
 ruleTester.run('default-exports', rule, {
   valid: [
+    'export default { }',
     "export default { title: 'Button', component: Button }",
     "export default { title: 'Button', component: Button } as ComponentMeta<typeof Button>",
     `
@@ -38,6 +39,10 @@ ruleTester.run('default-exports', rule, {
   invalid: [
     {
       code: 'export const Primary = () => <button>hello</button>',
+      output: dedent`
+        export default {}
+        export const Primary = () => <button>hello</button>
+      `,
       errors: [
         {
           messageId: 'shouldHaveDefaultExport',
@@ -78,18 +83,12 @@ ruleTester.run('default-exports', rule, {
     },
     {
       code: dedent`
-        import { Something } from './MyComponent'
+        import { MyComponentProps } from './MyComponent'
         export const Primary = () => <button>hello</button>
       `,
-      errors: [
-        {
-          messageId: 'shouldHaveDefaultExport',
-        },
-      ],
-    },
-    {
-      code: dedent`
-        import { MyComponent } from './Something'
+      output: dedent`
+        import { MyComponentProps } from './MyComponent'
+        export default {}
         export const Primary = () => <button>hello</button>
       `,
       errors: [


### PR DESCRIPTION
Issue: N/A

## What Changed

<!-- Insert a description below. Don't forget to run `yarn update-all` to update configuration files and their documentation! -->
`default-exports` rule now autofixes even if the component is not imported. In that case, it will add an empty export like:

```js
export default {}
```

## Checklist

Check the ones applicable to your change:

- [x] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
