### PR TITLE
fix(no-uninstalled-addons): ignore local addons

### DIFF
--- a/lib/rules/no-uninstalled-addons.ts
+++ b/lib/rules/no-uninstalled-addons.ts
@@ -62,8 +62,12 @@ export = createStorybookRule({
 
     type IsAddonInstalled = (addon: string, installedAddons: string[]) => boolean
     const isAddonInstalled: IsAddonInstalled = (addon, installedAddons) => {
-      // cleanup /register or /preset from registered addon
-      const addonName = addon.replace(/\/register$/, '').replace(/\/preset$/, '')
+      // cleanup /register or /preset + file extension from registered addon
+      const addonName = addon
+        .replace(/\.[mc]?js$/, '')
+        .replace(/\/register$/, '')
+        .replace(/\/preset$/, '')
+
       return installedAddons.includes(addonName)
     }
 
@@ -73,6 +77,8 @@ export = createStorybookRule({
     ) => false | { name: string }[]
     const areThereAddonsNotInstalled: AreThereAddonsNotInstalled = (addons, installedSbAddons) => {
       const result = addons
+        // remove local addons (e.g. ./my-addon/register.js)
+        .filter((addon) => !addon.startsWith('.'))
         .filter((addon) => !isAddonInstalled(addon, installedSbAddons))
         .map((addon) => ({ name: addon }))
       return result.length ? result : false

--- a/tests/lib/rules/no-uninstalled-addons.test.ts
+++ b/tests/lib/rules/no-uninstalled-addons.test.ts
@@ -16,32 +16,13 @@ jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
   readFileSync: () => `
     {
-      "name": "react-repro",
-      "version": "1.0.0",
-      "main": "index.js",
-      "license": "MIT",
-      "dependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      },
-      "packageManager": "yarn@3.2.1",
       "devDependencies": {
-        "@babel/core": "^7.18.5",
-        "@mdx-js/react": "^1.6.22",
-        "@storybook/addon-actions": "^6.5.9",
-        "@storybook/addon-docs": "^6.5.9",
         "@storybook/addon-essentials": "^6.5.9",
         "@storybook/addon-interactions": "^6.5.9",
         "@storybook/preset-create-react-app": "^6.5.9",
         "@storybook/addon-links": "^6.5.9",
-        "@storybook/builder-webpack4": "^6.5.9",
-        "@storybook/manager-webpack4": "^6.5.9",
-        "@storybook/react": "^6.5.9",
-        "@storybook/testing-library": "^0.0.13",
         "storybook-addon-valid-addon": "0.0.1",
-        "addon-without-the-prefix": "^0.0.1",
-        "babel-loader": "^8.2.5",
-        "prop-types": "^15.8.1"
+        "addon-without-the-prefix": "^0.0.1"
       }
     }
   `,
@@ -52,11 +33,6 @@ jest.mock('fs', () => ({
 //------------------------------------------------------------------------------
 
 ruleTester.run('no-uninstalled-addons', rule, {
-  /**
-   * This is an example test for a  rule that reports an error in case a named export is called 'wrong'
-   * Use https://eslint.org/docs/developer-guide/working-with-rules for Eslint API
-   * And delete this entire comment block
-   */
   valid: [
     `
     export default {
@@ -113,6 +89,14 @@ ruleTester.run('no-uninstalled-addons', rule, {
       }
   `,
     `
+      module.exports = {
+          addons: [
+            "../my-local-addon",
+            "../my-local-addon/index.cjs",
+          ]
+        }
+    `,
+    `
     module.exports = {
         addons: [
           {
@@ -124,7 +108,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
             name: "addon-without-the-prefix",
           },
           {
-            name: "storybook-addon-valid-addon/register",
+            name: "storybook-addon-valid-addon/register.js",
           },
         ]
       }
@@ -279,6 +263,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
     {
       code: `
         export const addons = [
+          "../my-local-addon",
           "@storybook/addon-links",
           "@storybook/addon-essentials",
           "@storybook/addon-interactions",


### PR DESCRIPTION
Issue: #97

## What Changed

This PR adds a fix for addons which are locally registered such as:

```js
// .storybook/main.js
module.exports = {
  addons: [
    './my-addon/preset.cjs', // <-- ignored in the checks
    '@storybook/addon-essentials'
  ]
}
```

## Checklist

Check the ones applicable to your change:

- [x] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
