### PR TITLE
feat(no-uninstalled-addons): add option for a custom package.json location

### DIFF
--- a/docs/rules/no-uninstalled-addons.md
+++ b/docs/rules/no-uninstalled-addons.md
@@ -68,7 +68,7 @@ module.exports = {
 
 ### Configure
 
-Some Storybook folders use a different name for their config directory other than `.storybook`. This rule will not be applied there by default. If you want to have it, then you must add an override in your `.eslintrc.js` file, defining your config directory:
+Some Storybook folders use a different name for their config directory other than `.storybook`. This rule will not be applied there by default. Also, this rule will use the package.json in the folder where ESLint is running, which is in most cases the root folder of the project. If you have custom location for your storybook config directory and/or a different location of your package.json, then you must add an override in your `.eslintrc.js` file, defining your config directory:
 
 ```js
 {
@@ -77,11 +77,14 @@ Some Storybook folders use a different name for their config directory other tha
         files: ['your-config-dir/main.@(js|cjs|mjs|ts)'],
         rules: {
           'storybook/no-uninstalled-addons': 'error',
+          { packageJsonLocation: './folder/package.json'}
         },
       },
     ],
 }
 ```
+
+Note that the path must be relative to where ESLint runs from, which is usually relative to the root of the project.
 
 ## When Not To Use It
 

--- a/docs/rules/no-uninstalled-addons.md
+++ b/docs/rules/no-uninstalled-addons.md
@@ -8,13 +8,13 @@
 
 ## Rule Details
 
-This rule checks if all addons in the storybook main.js file are properly listed in the root package.json of the npm project.
+This rule checks if all addons registered in `.storybook/main.js` are properly listed in the root package.json of your project.
 
 For instance, if the `@storybook/addon-links` is in the `.storybook/main.js` but is not listed in the `package.json` of the project, this rule will notify the user to add the addon to the package.json and install it.
 
-As an important side note, this rule will check for the package.json in the same level of the .storybook folder.
+As an important side note, this rule will check for the `package.json` in the **root level** of your project. You can customize the location of the `package.json` by [setting the `packageJsonPath` option](#configure).
 
-Another very important side note: your ESLint config must allow the linting of the .storybook folder. By default, ESLint ignores all dot-files so this folder will be ignored. In order to allow this rule to lint the .storybook/main.js file, it's important to configure ESLint to lint this file. This can be achieved by writing something like:
+Another very important side note: your ESLint config must allow the linting of the `.storybook` folder. By default, ESLint ignores all dot-files so this folder will be ignored. In order to allow this rule to lint the `.storybook/main.js` file, it's important to configure ESLint to lint this file. This can be achieved by writing something like:
 
 ```
 // Inside your .eslintignore file
@@ -68,7 +68,21 @@ module.exports = {
 
 ### Configure
 
-Some Storybook folders use a different name for their config directory other than `.storybook`. This rule will not be applied there by default. Also, this rule will use the package.json in the folder where ESLint is running, which is in most cases the root folder of the project. If you have custom location for your storybook config directory and/or a different location of your package.json, then you must add an override in your `.eslintrc.js` file, defining your config directory:
+This rule assumes that the `package.json` is located in the root of your project. You can customize this by setting the `packageJsonPath` option of the rule:
+
+```js
+module.exports = {
+  rules: {
+    'storybook/no-uninstalled-addons': ['error', { packageJsonLocation: './folder/package.json' }],
+  },
+}
+```
+
+Note that the path must be relative to where ESLint runs from, which is usually relative to the root of the project.
+
+### What if I use a different storybook config directory?
+
+Some Storybook folders use a different name for their config directory other than `.storybook`. This rule will not be applied there by default. If you have a custom location for your storybook config directory, then you must add an override in your `.eslintrc.js` file, defining your config directory:
 
 ```js
 {
@@ -76,15 +90,12 @@ Some Storybook folders use a different name for their config directory other tha
       {
         files: ['your-config-dir/main.@(js|cjs|mjs|ts)'],
         rules: {
-          'storybook/no-uninstalled-addons': 'error',
-          { packageJsonLocation: './folder/package.json'}
+          'storybook/no-uninstalled-addons': 'error'
         },
       },
     ],
 }
 ```
-
-Note that the path must be relative to where ESLint runs from, which is usually relative to the root of the project.
 
 ## When Not To Use It
 

--- a/lib/configs/addon-interactions.ts
+++ b/lib/configs/addon-interactions.ts
@@ -17,7 +17,7 @@ export = {
       },
     },
     {
-      files: ['main.@(js|cjs|mjs|ts)'],
+      files: ['.storybook/main.@(js|cjs|mjs|ts)'],
       rules: {
         'storybook/no-uninstalled-addons': 'error',
       },

--- a/lib/configs/csf.ts
+++ b/lib/configs/csf.ts
@@ -18,7 +18,7 @@ export = {
       },
     },
     {
-      files: ['main.@(js|cjs|mjs|ts)'],
+      files: ['.storybook/main.@(js|cjs|mjs|ts)'],
       rules: {
         'storybook/no-uninstalled-addons': 'error',
       },

--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -22,7 +22,7 @@ export = {
       },
     },
     {
-      files: ['main.@(js|cjs|mjs|ts)'],
+      files: ['.storybook/main.@(js|cjs|mjs|ts)'],
       rules: {
         'storybook/no-uninstalled-addons': 'error',
       },

--- a/lib/rules/no-uninstalled-addons.ts
+++ b/lib/rules/no-uninstalled-addons.ts
@@ -4,7 +4,8 @@
  */
 
 import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import dedent from 'ts-dedent'
+import { resolve, relative } from 'path'
 
 import { createStorybookRule } from '../utils/create-storybook-rule'
 import { CategoryId } from '../utils/constants'
@@ -35,7 +36,7 @@ export = createStorybookRule({
       recommended: 'error', // or 'error'
     },
     messages: {
-      addonIsNotInstalled: `The {{ addonName }} is not installed. Did you forget to install it?`,
+      addonIsNotInstalled: `The {{ addonName }} is not installed in {{packageJsonPath}}. Did you forget to install it or is your package.json in a different location?`,
     },
 
     schema: [
@@ -110,7 +111,10 @@ export = createStorybookRule({
         packageJson.devDependencies = parsedFile.devDependencies || {}
       } catch (e) {
         throw new Error(
-          `The provided path in your eslintrc.json - ${path} is not a valid path to a package.json file or your package.json file is not in the same folder as ESLint is running from.`
+          dedent`The provided path in your eslintrc.json - ${path} is not a valid path to a package.json file or your package.json file is not in the same folder as ESLint is running from.
+
+          Read more at: https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/no-uninstalled-addons.md
+          `
         )
       }
 
@@ -152,13 +156,10 @@ export = createStorybookRule({
     }
 
     function reportUninstalledAddons(addonsProp: ArrayExpression) {
-      // when this is running for .storybook/main.js, we get the path to the folder which contains the package.json of the
-      // project. This will be handy for monorepos that may be running ESLint in a node process in another folder.
-      const getProjectRoot = () =>
-        context.getPhysicalFilename ? resolve(context.getPhysicalFilename(), '../../') : './'
+      const packageJsonPath = resolve(packageJsonLocation || `./package.json`)
       let packageJsonObject: Record<string, any>
       try {
-        packageJsonObject = getPackageJson(packageJsonLocation || `./package.json`)
+        packageJsonObject = getPackageJson(packageJsonPath)
       } catch (e) {
         // if we cannot find the package.json, we cannot check if the addons are installed
         throw new Error(e as string)
@@ -174,11 +175,18 @@ export = createStorybookRule({
         const elemsWithErrors = listOfAddonElements.filter(
           (elem) => !!result.find((addon) => addon.name === elem.value)
         )
+
+        const rootDir = process.cwd().split('/').pop()
+        const packageJsonPath = `${rootDir}/${relative(process.cwd(), packageJsonLocation)}`
+
         elemsWithErrors.forEach((elem) => {
           context.report({
             node: elem.node,
             messageId: 'addonIsNotInstalled',
-            data: { addonName: elem.value },
+            data: {
+              addonName: elem.value,
+              packageJsonPath,
+            },
           })
         })
       }


### PR DESCRIPTION
Issue: #101

## What Changed

<!-- Insert a description below. Don't forget to run `yarn update-all` to update configuration files and their documentation! -->

## Checklist

Check the ones applicable to your change:

- [x] Ran `yarn update-all`
- [ ] Tests are updated
- [x] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`


### Release Notes

#### feat(no-uninstalled-addons): add option for a custom package.json location ([#102](https://github.com/storybookjs/eslint-plugin-storybook/pull/102))

### Features
 
The `no-uninstalled-addons` feature had an issue where it was assuming that the `package.json` of which the addon dependencies are installed was always in the root, and for some projects that was not true. For that scenario, the rule now provides an option to specify the exact path of the package.json:

```
module.exports = {
  rules: {
    'storybook/no-uninstalled-addons': ['error', { packageJsonLocation: './custom-folder/package.json' }],
  },
}
```