### PR TITLE
deps: move ts-dedent to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "@storybook/csf": "^0.0.1",
     "@typescript-eslint/experimental-utils": "^5.3.0",
-    "requireindex": "^1.1.0"
+    "requireindex": "^1.1.0",
+    "ts-dedent": "^2.2.0"
   },
   "devDependencies": {
     "@auto-it/released": "^10.32.2",
@@ -68,7 +69,6 @@
     "prettier": "^2.4.0",
     "prompts": "^2.4.2",
     "rimraf": "^3.0.2",
-    "ts-dedent": "^2.2.0",
     "ts-jest": "^27.0.7",
     "ts-migrate": "^0.1.26",
     "ts-node": "^10.4.0",

--- a/tests/lib/rules/no-uninstalled-addons.test.ts
+++ b/tests/lib/rules/no-uninstalled-addons.test.ts
@@ -133,6 +133,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/not-installed-addon',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
       ],
@@ -156,6 +157,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/not-installed-addon',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
       ],
@@ -178,6 +180,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/addon-esentials',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
       ],
@@ -198,6 +201,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/adon-essentials',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
       ],
@@ -220,6 +224,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: 'addon-withut-the-prefix',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
         {
@@ -227,6 +232,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/addon-esentials',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
       ],
@@ -249,6 +255,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: 'addon-withut-the-prefix',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
         {
@@ -256,6 +263,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/addon-esentials',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
       ],
@@ -277,6 +285,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: 'addon-withut-the-prefix',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
         {
@@ -284,6 +293,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/addon-esentials',
+            packageJsonPath: 'eslint-plugin-storybook/',
           },
         },
       ],


### PR DESCRIPTION
Issue: #103 

## What Changed

`ts-dedent` was used in a rule but was defined as dev-dependency. This PR fixes that

## Checklist

Check the ones applicable to your change:

- [x] Ran `yarn update-all`
- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.3--canary.104.2956130.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-plugin-storybook@0.6.3--canary.104.2956130.0
  # or 
  yarn add eslint-plugin-storybook@0.6.3--canary.104.2956130.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
