### PR TITLE
story-exports: provide better feedback when using filters

### DIFF
--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -33,6 +33,8 @@ export = createStorybookRule({
     },
     messages: {
       shouldHaveStoryExport: 'The file should have at least one story export',
+      shouldHaveStoryExportWithFilters:
+        'The file should have at least one story export. Make sure the includeStories/excludeStories you defined are correct, otherwise Storybook will not use any stories for this file.',
       addStoryExport: 'Add a story export',
     },
     fixable: undefined, // change to 'code' once we have autofixes
@@ -94,9 +96,11 @@ export = createStorybookRule({
         // @TODO: bring apply this autofix with CSF3 release
         // const fix = (fixer) => fixer.insertTextAfter(node, `\n\nexport const Default = {}`)
 
+        const hasFilter =
+          nonStoryExportsConfig.includeStories || nonStoryExportsConfig.excludeStories
         const report = {
           node,
-          messageId: 'shouldHaveStoryExport',
+          messageId: hasFilter ? 'shouldHaveStoryExportWithFilters' : 'shouldHaveStoryExport',
           // fix,
         } as const
 

--- a/tests/lib/rules/story-exports.test.ts
+++ b/tests/lib/rules/story-exports.test.ts
@@ -103,7 +103,7 @@ ruleTester.run('story-exports', rule, {
       // `,
       errors: [
         {
-          messageId: 'shouldHaveStoryExport',
+          messageId: 'shouldHaveStoryExportWithFilters',
         },
       ],
     },
@@ -132,7 +132,7 @@ ruleTester.run('story-exports', rule, {
       // `,
       errors: [
         {
-          messageId: 'shouldHaveStoryExport',
+          messageId: 'shouldHaveStoryExportWithFilters',
         },
       ],
     },
@@ -155,7 +155,7 @@ ruleTester.run('story-exports', rule, {
       // `,
       errors: [
         {
-          messageId: 'shouldHaveStoryExport',
+          messageId: 'shouldHaveStoryExportWithFilters',
         },
       ],
     },


### PR DESCRIPTION
Issue: N/A

## What Changed

The `story-exports` rule now detects whether you are using `includeStories/excludeStories` and provides a more helpful message in case there are not exported stories. A possible scenario is you have a typo in your `includeStories` which will result in Storybook not including it:

```js
export default {
  title: 'Button',
  includeStories: ['myStory'], // <-- notice the lowercase m, which won't match with the story name
};

export const MyStory = {};
```

>The file should have at least one story export. Make sure the includeStories/excludeStories you defined are correct, otherwise Storybook will not use any stories for this file.'

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`

### Release notes

The `story-exports` rule now detects whether you are using `includeStories/excludeStories` and provides a more helpful message in case there are not exported stories. A possible scenario is you have a typo in your `includeStories` which will result in Storybook not including it:

```js
export default {
  title: 'Button',
  includeStories: ['myStory'], // <-- notice the lowercase m, which won't match with the story name
};

export const MyStory = {};
```