### PR TITLE
fix(no-uninstalled-addons) Support Windows paths

### DIFF
--- a/lib/rules/no-uninstalled-addons.ts
+++ b/lib/rules/no-uninstalled-addons.ts
@@ -5,7 +5,7 @@
 
 import { readFileSync } from 'fs'
 import dedent from 'ts-dedent'
-import { resolve, relative } from 'path'
+import { resolve, relative, sep } from 'path'
 
 import { createStorybookRule } from '../utils/create-storybook-rule'
 import { CategoryId } from '../utils/constants'
@@ -187,8 +187,8 @@ export = createStorybookRule({
           (elem) => !!result.find((addon) => addon.name === elem.value)
         )
 
-        const rootDir = process.cwd().split('/').pop()
-        const packageJsonPath = `${rootDir}/${relative(process.cwd(), packageJsonLocation)}`
+        const rootDir = process.cwd().split(sep).pop()
+        const packageJsonPath = `${rootDir}${sep}${relative(process.cwd(), packageJsonLocation)}`
 
         elemsWithErrors.forEach((elem) => {
           context.report({

--- a/tests/lib/rules/no-uninstalled-addons.test.ts
+++ b/tests/lib/rules/no-uninstalled-addons.test.ts
@@ -11,6 +11,7 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
 import rule from '../../../lib/rules/no-uninstalled-addons'
 import ruleTester from '../../utils/rule-tester'
+import { sep } from 'path';
 
 jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
@@ -137,7 +138,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/not-installed-addon',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
       ],
@@ -161,7 +162,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/not-installed-addon',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
       ],
@@ -184,7 +185,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/addon-esentials',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
       ],
@@ -205,7 +206,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/adon-essentials',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
       ],
@@ -228,7 +229,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: 'addon-withut-the-prefix',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
         {
@@ -236,7 +237,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/addon-esentials',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
       ],
@@ -259,7 +260,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: 'addon-withut-the-prefix',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
         {
@@ -267,7 +268,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/addon-esentials',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
       ],
@@ -289,7 +290,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: 'addon-withut-the-prefix',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
         {
@@ -297,7 +298,7 @@ ruleTester.run('no-uninstalled-addons', rule, {
           type: AST_NODE_TYPES.Literal,
           data: {
             addonName: '@storybook/addon-esentials',
-            packageJsonPath: 'eslint-plugin-storybook/',
+            packageJsonPath: `eslint-plugin-storybook${sep}`,
           },
         },
       ],


### PR DESCRIPTION
## What Changed

![image](https://user-images.githubusercontent.com/16818271/209861498-184d23e9-6374-419e-afd1-17f3fcc8a5a2.png)

Running the tests fails on Windows because of the way paths are being resolved inside the `no-uninstalled-addons` rule. 

* Replaced the relevant `/` occurrences with `path.sep` which should just work for both POSIX and Windows.
*  Updated the tests accordingly.

## Checklist

Check the ones applicable to your change:

- [X] Ran `yarn update-all`
- [X] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
