### PR TITLE
chore: fix ESLint and TypeScript issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,9 +5,11 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:eslint-plugin/recommended',
-    'plugin:node/recommended',
     'plugin:prettier/recommended',
+    'plugin:@typescript-eslint/recommended',
   ],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
   env: {
     node: true,
   },

--- a/lib/rules/await-interactions.ts
+++ b/lib/rules/await-interactions.ts
@@ -159,7 +159,7 @@ export = createStorybookRule({
      */
 
     let isImportedFromStorybook = true
-    let invocationsThatShouldBeAwaited = [] as Array<{
+    const invocationsThatShouldBeAwaited = [] as Array<{
       node: TSESTree.Node
       method: TSESTree.Identifier
     }>

--- a/lib/rules/context-in-play-function.ts
+++ b/lib/rules/context-in-play-function.ts
@@ -3,7 +3,7 @@
  * @author Yann Braga
  */
 
-import { TSESTree } from "@typescript-eslint/utils";
+import { TSESTree } from '@typescript-eslint/utils'
 
 import { createStorybookRule } from '../utils/create-storybook-rule'
 import { CategoryId } from '../utils/constants'
@@ -100,7 +100,7 @@ export = createStorybookRule({
     // Public
     //----------------------------------------------------------------------
 
-    let invocationsWithoutProperContext: TSESTree.Node[] = [];
+    const invocationsWithoutProperContext: TSESTree.Node[] = []
 
     return {
       CallExpression(node: TSESTree.CallExpression) {

--- a/lib/rules/csf-component.ts
+++ b/lib/rules/csf-component.ts
@@ -3,7 +3,7 @@
  * @author Yann Braga
  */
 
-import { TSESTree } from "@typescript-eslint/utils";
+import { TSESTree } from '@typescript-eslint/utils'
 import { getMetaObjectExpression } from '../utils'
 import { CategoryId } from '../utils/constants'
 import { createStorybookRule } from '../utils/create-storybook-rule'

--- a/lib/rules/hierarchy-separator.ts
+++ b/lib/rules/hierarchy-separator.ts
@@ -3,7 +3,7 @@
  * @author Yann Braga
  */
 
-import { TSESTree } from "@typescript-eslint/utils";
+import { TSESTree } from '@typescript-eslint/utils'
 import { getMetaObjectExpression } from '../utils'
 import { isLiteral, isSpreadElement } from '../utils/ast'
 import { CategoryId } from '../utils/constants'

--- a/lib/rules/meta-inline-properties.ts
+++ b/lib/rules/meta-inline-properties.ts
@@ -78,7 +78,7 @@ export = createStorybookRule({
         }
 
         const ruleProperties = ['title', 'args']
-        let dynamicProperties: TDynamicProperty[] = []
+        const dynamicProperties: TDynamicProperty[] = []
 
         const metaNodes = meta.properties.filter(
           (prop) => 'key' in prop && 'name' in prop.key && ruleProperties.includes(prop.key.name)

--- a/lib/rules/no-title-property-in-meta.ts
+++ b/lib/rules/no-title-property-in-meta.ts
@@ -3,7 +3,7 @@
  * @author Yann Braga
  */
 
-import { TSESTree } from "@typescript-eslint/utils";
+import { TSESTree } from '@typescript-eslint/utils'
 import { getMetaObjectExpression } from '../utils'
 import { CategoryId } from '../utils/constants'
 import { createStorybookRule } from '../utils/create-storybook-rule'

--- a/lib/rules/no-uninstalled-addons.ts
+++ b/lib/rules/no-uninstalled-addons.ts
@@ -18,7 +18,7 @@ import {
   isVariableDeclarator,
   isVariableDeclaration,
 } from '../utils/ast'
-import { TSESTree } from "@typescript-eslint/utils";
+import { TSESTree } from '@typescript-eslint/utils'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -66,7 +66,7 @@ export = createStorybookRule({
       return !!item
     }
 
-    type MergeDepsWithDevDeps = (packageJson: Record<string, string>) => string[]
+    type MergeDepsWithDevDeps = (packageJson: PackageJsonDependencies) => string[]
     const mergeDepsWithDevDeps: MergeDepsWithDevDeps = (packageJson) => {
       const deps = Object.keys(packageJson.dependencies || {})
       const devDeps = Object.keys(packageJson.devDependencies || {})
@@ -108,7 +108,12 @@ export = createStorybookRule({
       return result.length ? result : false
     }
 
-    type GetPackageJson = (path: string) => Record<string, any>
+    type PackageJsonDependencies = {
+      devDependencies: Record<string, string>
+      dependencies: Record<string, string>
+    }
+
+    type GetPackageJson = (path: string) => PackageJsonDependencies
 
     const getPackageJson: GetPackageJson = (path) => {
       const packageJson = {
@@ -168,7 +173,7 @@ export = createStorybookRule({
 
     function reportUninstalledAddons(addonsProp: TSESTree.ArrayExpression) {
       const packageJsonPath = resolve(packageJsonLocation || `./package.json`)
-      let packageJsonObject: Record<string, any>
+      let packageJsonObject: PackageJsonDependencies
       try {
         packageJsonObject = getPackageJson(packageJsonPath)
       } catch (e) {

--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -3,7 +3,7 @@
  * @author Yann Braga
  */
 
-import { ASTUtils, TSESTree } from "@typescript-eslint/utils";
+import { ASTUtils, TSESTree } from '@typescript-eslint/utils'
 import { IncludeExcludeOptions, isExportStory } from '@storybook/csf'
 
 import { getDescriptor, getMetaObjectExpression } from '../utils'
@@ -83,7 +83,7 @@ export = createStorybookRule({
                   const referenceCount = variable?.references?.length || 0
 
                   for (let i = 0; i < referenceCount; i++) {
-                    const ref = variable!.references[i]
+                    const ref = variable?.references[i]
                     if (ref && !ref.init) {
                       yield fixer.replaceTextRange(ref.identifier.range, pascal)
                     }
@@ -102,7 +102,7 @@ export = createStorybookRule({
 
     let meta
     let nonStoryExportsConfig: IncludeExcludeOptions
-    let namedExports: TSESTree.Identifier[] = []
+    const namedExports: TSESTree.Identifier[] = []
     let hasStoriesOfImport = false
 
     return {
@@ -119,7 +119,9 @@ export = createStorybookRule({
               excludeStories: getDescriptor(meta, 'excludeStories'),
               includeStories: getDescriptor(meta, 'includeStories'),
             }
-          } catch (err) {}
+          } catch (err) {
+            //
+          }
         }
       },
       ExportNamedDeclaration: function (node: TSESTree.ExportNamedDeclaration) {

--- a/lib/rules/story-exports.ts
+++ b/lib/rules/story-exports.ts
@@ -3,7 +3,6 @@
  * @author Yann Braga
  */
 
-
 import { createStorybookRule } from '../utils/create-storybook-rule'
 import { CategoryId } from '../utils/constants'
 import {
@@ -14,7 +13,7 @@ import {
 } from '../utils'
 import { isImportDeclaration } from '../utils/ast'
 import { IncludeExcludeOptions } from '@storybook/csf'
-import { TSESTree } from "@typescript-eslint/utils";
+import { TSESTree } from '@typescript-eslint/utils'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -54,7 +53,7 @@ export = createStorybookRule({
     let hasStoriesOfImport = false
     let nonStoryExportsConfig: IncludeExcludeOptions = {}
     let meta: TSESTree.ObjectExpression | null
-    let namedExports: TSESTree.Identifier[] = []
+    const namedExports: TSESTree.Identifier[] = []
 
     return {
       ImportSpecifier(node) {
@@ -70,7 +69,9 @@ export = createStorybookRule({
               excludeStories: getDescriptor(meta, 'excludeStories'),
               includeStories: getDescriptor(meta, 'includeStories'),
             }
-          } catch (err) {}
+          } catch (err) {
+            //
+          }
         }
       },
       ExportNamedDeclaration: function (node) {

--- a/lib/rules/use-storybook-expect.ts
+++ b/lib/rules/use-storybook-expect.ts
@@ -7,7 +7,7 @@ import { CategoryId } from '../utils/constants'
 import { isIdentifier, isImportSpecifier } from '../utils/ast'
 
 import { createStorybookRule } from '../utils/create-storybook-rule'
-import { TSESTree } from "@typescript-eslint/utils";
+import { TSESTree } from '@typescript-eslint/utils'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -56,7 +56,7 @@ export = createStorybookRule<TDefaultOptions, string>({
     //----------------------------------------------------------------------
 
     let isImportingFromStorybookExpect = false
-    let expectInvocations: TSESTree.Identifier[] = []
+    const expectInvocations: TSESTree.Identifier[] = []
 
     return {
       ImportDeclaration(node) {

--- a/lib/rules/use-storybook-testing-library.ts
+++ b/lib/rules/use-storybook-testing-library.ts
@@ -6,7 +6,7 @@
 import { isImportDefaultSpecifier } from '../utils/ast'
 import { CategoryId } from '../utils/constants'
 import { createStorybookRule } from '../utils/create-storybook-rule'
-import { TSESTree } from "@typescript-eslint/utils";
+import { TSESTree } from '@typescript-eslint/utils'
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -5,16 +5,9 @@ export type RuleModule = TSESLint.RuleModule<'', []> & {
   meta: { hasSuggestions?: boolean; docs: { recommendedConfig?: 'error' | 'warn' } }
 }
 
-type RecommendedConfig<TOptions extends readonly unknown[]> =
-  | TSESLint.RuleMetaDataDocs['recommended']
-  | [TSESLint.RuleMetaDataDocs['recommended'], ...TOptions]
-
 // These 2 types are copied from @typescript-eslint/experimental-utils' CreateRuleMeta
 // and modified to our needs
-export type StorybookRuleMetaDocs<TOptions extends readonly unknown[]> = Omit<
-  TSESLint.RuleMetaDataDocs,
-  'url'
-> & {
+export type StorybookRuleMetaDocs = Omit<TSESLint.RuleMetaDataDocs, 'url'> & {
   /**
    * Whether or not this rule should be excluded from linter config
    */
@@ -24,20 +17,21 @@ export type StorybookRuleMetaDocs<TOptions extends readonly unknown[]> = Omit<
    */
   categories?: CategoryId[]
 }
-export type StorybookRuleMeta<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[]
-> = Omit<TSESLint.RuleMetaData<TMessageIds>, 'docs'> & {
-  docs: StorybookRuleMetaDocs<TOptions>
+
+export type StorybookRuleMeta<TMessageIds extends string> = Omit<
+  TSESLint.RuleMetaData<TMessageIds>,
+  'docs'
+> & {
+  docs: StorybookRuleMetaDocs
 }
 
-// const docs: StorybookRuleMetaDocs<any> = {
-//   recommended: true,
+// Comment out for testing purposes:
+// const docs: StorybookRuleMetaDocs = {
 //   description: 'bla',
 //   recommended: 'error',
 // }
 
-// const meta: StorybookRuleMeta<'someId', any> = {
+// const meta: StorybookRuleMeta<'someId'> = {
 //   messages: {
 //     someId: 'yea',
 //   },

--- a/lib/utils/create-storybook-rule.ts
+++ b/lib/utils/create-storybook-rule.ts
@@ -13,7 +13,7 @@ export function createStorybookRule<
   ...remainingConfig
 }: Readonly<{
   name: string
-  meta: StorybookRuleMeta<TMessageIds, TOptions>
+  meta: StorybookRuleMeta<TMessageIds>
   defaultOptions: Readonly<TOptions>
   create: (
     context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -57,11 +57,11 @@ export const getDescriptor = (
         if (!['StringLiteral', 'Literal'].includes(t.type)) {
           throw new Error(`Unexpected descriptor element: ${t.type}`)
         }
+        // @ts-expect-error TODO: t should be only StringLiteral or Literal, and the type is not resolving correctly
         return t.value
       })
     case 'Literal':
-    // TODO: Investigation needed. Type systems says, that "RegExpLiteral" does not exist
-    // @ts-ignore
+    // @ts-expect-error TODO: Investigation needed. Type systems says, that "RegExpLiteral" does not exist
     case 'RegExpLiteral':
       // @ts-ignore
       return property.value.value

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -57,7 +57,6 @@ export const getDescriptor = (
         if (!['StringLiteral', 'Literal'].includes(t.type)) {
           throw new Error(`Unexpected descriptor element: ${t.type}`)
         }
-        // @ts-ignore
         return t.value
       })
     case 'Literal':

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.6",
     "@types/requireindex": "^1.2.0",
+    "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.3.0",
     "auto": "^10.32.2",
     "eslint": "^7.1.0",

--- a/tools/update-configs.ts
+++ b/tools/update-configs.ts
@@ -20,7 +20,7 @@ const externalRuleOverrides = {
 }
 
 function formatRules(rules: TCategory['rules'], exclude?: string[]) {
-  const obj = rules?.reduce(
+  const obj = rules.reduce(
     (setting, rule) => {
       if (!exclude?.includes(rule.ruleId)) {
         setting[rule.ruleId] = rule.meta.docs.recommended || 'error'
@@ -28,13 +28,13 @@ function formatRules(rules: TCategory['rules'], exclude?: string[]) {
       return setting
     },
     { ...externalRuleOverrides }
-  ) ?? { ...externalRuleOverrides }
+  )
 
   return JSON.stringify(obj, null, 2)
 }
 
 function formatSingleRule(rules: TCategory['rules'], ruleId: string) {
-  const ruleOpt = rules?.find((rule) => rule.ruleId === ruleId)?.meta.docs.recommended || 'error'
+  const ruleOpt = rules.find((rule) => rule.ruleId === ruleId)?.meta.docs.recommended || 'error'
 
   return JSON.stringify({ [ruleId]: ruleOpt }, null, 2)
 }

--- a/tools/update-configs.ts
+++ b/tools/update-configs.ts
@@ -20,7 +20,7 @@ const externalRuleOverrides = {
 }
 
 function formatRules(rules: TCategory['rules'], exclude?: string[]) {
-  const obj = rules.reduce(
+  const obj = rules?.reduce(
     (setting, rule) => {
       if (!exclude?.includes(rule.ruleId)) {
         setting[rule.ruleId] = rule.meta.docs.recommended || 'error'
@@ -28,13 +28,13 @@ function formatRules(rules: TCategory['rules'], exclude?: string[]) {
       return setting
     },
     { ...externalRuleOverrides }
-  )
+  ) ?? { ...externalRuleOverrides }
 
   return JSON.stringify(obj, null, 2)
 }
 
 function formatSingleRule(rules: TCategory['rules'], ruleId: string) {
-  const ruleOpt = rules.find((rule) => rule.ruleId === ruleId)?.meta.docs.recommended || 'error'
+  const ruleOpt = rules?.find((rule) => rule.ruleId === ruleId)?.meta.docs.recommended || 'error'
 
   return JSON.stringify({ [ruleId]: ruleOpt }, null, 2)
 }

--- a/tools/update-rules-list.ts
+++ b/tools/update-rules-list.ts
@@ -30,7 +30,9 @@ const rulesList: TRulesList[] = Object.entries(rules)
       createRuleLink(rule.name),
       rule.meta.docs.description,
       rule.meta.fixable ? emojiKey.fixable : '',
-      `<ul>${rule.meta.docs.categories.map((c) => `<li>${c}</li>`).join('')}</ul>`,
+      rule.meta.docs.categories
+        ? `<ul>${rule.meta.docs.categories.map((c) => `<li>${c}</li>`).join('')}</ul>`
+        : '',
     ]
   })
 

--- a/tools/utils/categories.ts
+++ b/tools/utils/categories.ts
@@ -26,19 +26,19 @@ for (const categoryId of categoryIds) {
   for (const rule of rules) {
     const ruleCategories = rule.meta.docs.categories
     // Throw if rule does not have a category
-    if (!ruleCategories.length) {
+    if (!ruleCategories?.length) {
       throw new Error(`Rule "${rule.ruleId}" does not have any category.`)
     }
 
     if (ruleCategories.includes(categoryId)) {
-      categoriesConfig[categoryId].rules.push(rule)
+      categoriesConfig[categoryId].rules?.push(rule)
     }
   }
 }
 
 export const categories = categoryIds
   .map((categoryId) => {
-    if (!categoriesConfig[categoryId].rules.length) {
+    if (!categoriesConfig[categoryId].rules?.length) {
       throw new Error(
         `Category "${categoryId}" has no rules. Make sure that at least one rule is linked to this category.`
       )
@@ -47,11 +47,11 @@ export const categories = categoryIds
     return {
       categoryId,
       title: categoriesConfig[categoryId],
-      rules: categoriesConfig[categoryId].rules.filter((rule) => !rule.meta.deprecated),
+      rules: categoriesConfig[categoryId].rules?.filter((rule) => !rule.meta.deprecated) ?? [],
     }
   })
   .filter((category) => {
-    return category.rules.length >= 1
+    return (category.rules?.length ?? 0) >= 1
   })
 
 export type TCategory = typeof categories extends (infer TCat)[] ? TCat : never

--- a/tools/utils/categories.ts
+++ b/tools/utils/categories.ts
@@ -18,7 +18,7 @@ const categoriesConfig: TCategoriesConfig = {
   },
 }
 
-export const categoryIds = Object.keys(categoriesConfig)
+export const categoryIds = Object.keys(categoriesConfig) as CategoryId[]
 
 for (const categoryId of categoryIds) {
   categoriesConfig[categoryId].rules = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -1655,6 +1655,21 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript-eslint/eslint-plugin@^5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.47.1.tgz#50cc5085578a7fa22cd46a0806c2e5eae858af02"
+  integrity sha512-r4RZ2Jl9kcQN7K/dcOT+J7NAimbiis4sSM9spvWimsBvDegMhKLA5vri2jG19PmIPbDjPeWzfUPQ2hjEzA4Nmg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.47.1"
+    "@typescript-eslint/type-utils" "5.47.1"
+    "@typescript-eslint/utils" "5.47.1"
+    debug "^4.3.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    regexpp "^3.2.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/parser@^5.3.0":
   version "5.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.45.0.tgz#b18a5f6b3cf1c2b3e399e9d2df4be40d6b0ddd0e"
@@ -1673,10 +1688,33 @@
     "@typescript-eslint/types" "5.45.0"
     "@typescript-eslint/visitor-keys" "5.45.0"
 
+"@typescript-eslint/scope-manager@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.47.1.tgz#0d302b3c2f20ab24e4787bf3f5a0d8c449b823bd"
+  integrity sha512-9hsFDsgUwrdOoW1D97Ewog7DYSHaq4WKuNs0LHF9RiCmqB0Z+XRR4Pf7u7u9z/8CciHuJ6yxNws1XznI3ddjEw==
+  dependencies:
+    "@typescript-eslint/types" "5.47.1"
+    "@typescript-eslint/visitor-keys" "5.47.1"
+
+"@typescript-eslint/type-utils@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.47.1.tgz#aee13314f840ab336c1adb49a300856fd16d04ce"
+  integrity sha512-/UKOeo8ee80A7/GJA427oIrBi/Gd4osk/3auBUg4Rn9EahFpevVV1mUK8hjyQD5lHPqX397x6CwOk5WGh1E/1w==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.47.1"
+    "@typescript-eslint/utils" "5.47.1"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/types@5.45.0":
   version "5.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.45.0.tgz#794760b9037ee4154c09549ef5a96599621109c5"
   integrity sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==
+
+"@typescript-eslint/types@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.47.1.tgz#459f07428aec5a8c4113706293c2ae876741ac8e"
+  integrity sha512-CmALY9YWXEpwuu6377ybJBZdtSAnzXLSQcxLSqSQSbC7VfpMu/HLVdrnVJj7ycI138EHqocW02LPJErE35cE9A==
 
 "@typescript-eslint/typescript-estree@5.45.0":
   version "5.45.0"
@@ -1690,6 +1728,33 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.1.tgz#b9d8441308aca53df7f69b2c67a887b82c9ed418"
+  integrity sha512-4+ZhFSuISAvRi2xUszEj0xXbNTHceV9GbH9S8oAD2a/F9SW57aJNQVOCxG8GPfSWH/X4eOPdMEU2jYVuWKEpWA==
+  dependencies:
+    "@typescript-eslint/types" "5.47.1"
+    "@typescript-eslint/visitor-keys" "5.47.1"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.47.1.tgz#595f25ac06e9ee28c339fd43c709402820b13d7b"
+  integrity sha512-l90SdwqfmkuIVaREZ2ykEfCezepCLxzWMo5gVfcJsJCaT4jHT+QjgSkYhs5BMQmWqE9k3AtIfk4g211z/sTMVw==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.47.1"
+    "@typescript-eslint/types" "5.47.1"
+    "@typescript-eslint/typescript-estree" "5.47.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
 
 "@typescript-eslint/utils@^5.45.0":
   version "5.45.0"
@@ -1711,6 +1776,14 @@
   integrity sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==
   dependencies:
     "@typescript-eslint/types" "5.45.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.47.1":
+  version "5.47.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.1.tgz#d35c2da544dbb685db9c5b5b85adac0a1d74d1f2"
+  integrity sha512-rF3pmut2JCCjh6BLRhNKdYjULMb1brvoaiWDlHfLNVgmnZ0sBVJrs3SyaKE1XoDDnJuAx/hDQryHYmPUuNq0ig==
+  dependencies:
+    "@typescript-eslint/types" "5.47.1"
     eslint-visitor-keys "^3.3.0"
 
 abab@^2.0.3, abab@^2.0.5:
@@ -4657,6 +4730,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -5167,7 +5245,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.0.0, regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==


### PR DESCRIPTION
## What Changed

* Removed `plugin:node/recommended` from `.eslintrc.js` because it caused ESLint to raise a lot of `node/no-unsupported-features/es-syntax` errors in TypeScript files. I'm not sure why it was actually used, please let me know!
* Explicitly set ESLint parser to `@typescript-eslint/parser` so that it actually processes TypeScript files.
* Added `@typescript-eslint` `devDependencies` for better compatibility between ESLint and TypeScript (it disables conflicted rules e.g. `no-unused-args` when actually defining a type, etc.)
* Refined a bit some typing for the `no-uninstalled-addons` rule so that is is slightly more precise
* Ran the autofix in the whole project and manually fixed remaining warnings/errors
* Made sure to provide adequate fallbacks when using optional chaining after the above changes
* Unused types inside `lib/types/index.ts` (`RecommendedConfig`, the generic `TOptions` is on `StorybookRuleMetaDocs` which itself doesn't seem to be used anywhere) got removed.

## What did not change

* There is a whole block with an attached [TODO note](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/lib/utils/index.ts#L64-L68) which raises ESLint problems: I started to look into it. However, required changes look a bit less trivial, I guess it deserves a PR on its own so that it can be further discussed.
* Same thing about TypeScript and ESLint errors on the generated example rule.

## Checklist

Check the ones applicable to your change:

- [X] Ran `yarn update-all`
- [X] Tests are updated
- [X] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [X] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
