### PR TITLE
Refactor to reduce code duplication and refine types

### DIFF
--- a/lib/rules/hierarchy-separator.ts
+++ b/lib/rules/hierarchy-separator.ts
@@ -3,9 +3,8 @@
  * @author Yann Braga
  */
 
-import { TSESTree } from '@typescript-eslint/utils'
-import { getMetaObjectExpression } from '../utils'
-import { isLiteral, isSpreadElement } from '../utils/ast'
+import { getMetaObjectExpression, getObjectBareProperty } from '../utils'
+import { isLiteral } from '../utils/ast'
 import { CategoryId } from '../utils/constants'
 import { createStorybookRule } from '../utils/create-storybook-rule'
 
@@ -40,9 +39,7 @@ export = createStorybookRule({
           return null
         }
 
-        const titleNode = meta.properties.find(
-          (prop) => !isSpreadElement(prop) && 'name' in prop.key && prop.key?.name === 'title'
-        ) as TSESTree.MethodDefinition | TSESTree.Property | undefined
+        const titleNode = getObjectBareProperty(meta.properties, 'title')
 
         if (!titleNode || !isLiteral(titleNode.value)) {
           return

--- a/lib/rules/no-title-property-in-meta.ts
+++ b/lib/rules/no-title-property-in-meta.ts
@@ -4,10 +4,9 @@
  */
 
 import { TSESTree } from '@typescript-eslint/utils'
-import { getMetaObjectExpression } from '../utils'
+import { getMetaObjectExpression, getObjectBareProperty } from '../utils'
 import { CategoryId } from '../utils/constants'
 import { createStorybookRule } from '../utils/create-storybook-rule'
-import { isSpreadElement } from '../utils/ast'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -39,9 +38,7 @@ export = createStorybookRule({
           return null
         }
 
-        const titleNode = meta.properties.find(
-          (prop) => !isSpreadElement(prop) && 'name' in prop.key && prop.key?.name === 'title'
-        )
+        const titleNode = getObjectBareProperty(meta.properties, 'title')
 
         if (titleNode) {
           context.report({

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -41,3 +41,9 @@ export type StorybookRuleMeta<TMessageIds extends string> = Omit<
 // }
 
 export type NamedVariable = TSESTree.VariableDeclarator & { id: TSESTree.Identifier }
+
+export type ObjectLiteralItem = Exclude<TSESTree.ObjectLiteralElement, TSESTree.SpreadElement>
+
+export type StoryDescriptor = string[] | RegExp
+
+export type Maybe<T> = T | null | undefined

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/utils'
+import { TSESLint, TSESTree } from '@typescript-eslint/utils'
 import { CategoryId } from '../utils/constants'
 
 export type RuleModule = TSESLint.RuleModule<'', []> & {
@@ -39,3 +39,5 @@ export type StorybookRuleMeta<TMessageIds extends string> = Omit<
 //   schema: [],
 //   docs,
 // }
+
+export type NamedVariable = TSESTree.VariableDeclarator & { id: TSESTree.Identifier }

--- a/lib/utils/ast.ts
+++ b/lib/utils/ast.ts
@@ -1,9 +1,10 @@
 import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils'
+import { Maybe } from '../types'
 export { ASTUtils } from '@typescript-eslint/utils'
 
 const isNodeOfType =
   <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) =>
-  (node: TSESTree.Node | null | undefined): node is TSESTree.Node & { type: NodeType } =>
+  (node: Maybe<TSESTree.Node>): node is TSESTree.Node & { type: NodeType } =>
     node?.type === nodeType
 
 export const isAwaitExpression = isNodeOfType(AST_NODE_TYPES.AwaitExpression)


### PR DESCRIPTION
## What Changed

* #113 mentions some issues that were not addressed, especially these [todo notes](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/lib/utils/index.ts#L54-L71). I've made changes so that it actually follows [`@typescript-eslint/parser`'s output AST](https://astexplorer.net/#/gist/712951dab084a6a6a9d5072f10821a27/latest). All literals [are gathered](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/ast-spec/src/unions/Literal.ts#L8) in a `Literal` union type, which requires some type narrowing. According to [docs](https://storybook.js.org/docs/7.0/react/api/csf#non-story-exports) and [`@storybook/csf` types](https://github.com/ComponentDriven/csf/blob/next/src/index.ts#L39), descriptors should only support arrays of strings and single regexes, I've updated code accordingly.
* While browsing the code, I've came across some code duplication, and some code that could benefit from further splitting (to make tests easier, and maybe improve readability (not that much confident about that huh). I took the liberty of refactoring a bit what appeared relevant (at least to me). Please let me know if you think I got carried away 😅 

## Checklist

Check the ones applicable to your change:

- [X] Ran `yarn update-all`
- [ ] Tests are updated <- Didn't need to, but ran them to make sure everything's still okay!
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [X] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
