### PR TITLE
fix: prefer-pascal-case report error for non-latin characters

### DIFF
--- a/lib/rules/prefer-pascal-case.ts
+++ b/lib/rules/prefer-pascal-case.ts
@@ -15,6 +15,38 @@ import { createStorybookRule } from '../utils/create-storybook-rule'
 // Rule Definition
 //------------------------------------------------------------------------------
 
+function testDigit(char: string) {
+  const charCode = char.charCodeAt(0);
+  return charCode >= 48 && charCode <= 57;
+}
+
+function testUpperCase(char: string) {
+  const upperCase = char.toUpperCase();
+  return char === upperCase && upperCase !== char.toLowerCase();
+}
+
+function testLowerCase(char: string) {
+  const lowerCase = char.toLowerCase();
+  return char === lowerCase && lowerCase !== char.toUpperCase();
+}
+
+function testPascalCase(name: string) {
+  if (!testUpperCase(name.charAt(0))) {
+    return false;
+  }
+  const anyNonAlphaNumeric = Array.prototype.some.call(
+    name.slice(1),
+    (char) => char.toLowerCase() === char.toUpperCase() && !testDigit(char)
+  );
+  if (anyNonAlphaNumeric) {
+    return false;
+  }
+  return Array.prototype.some.call(
+    name.slice(1),
+    (char) => testLowerCase(char) || testDigit(char)
+  );
+}
+
 export = createStorybookRule({
   name: 'prefer-pascal-case',
   defaultOptions: [],
@@ -41,7 +73,7 @@ export = createStorybookRule({
     // Helpers
     //----------------------------------------------------------------------
 
-    const isPascalCase = (str: string) => /^[A-Z]+([a-z0-9]?)+/.test(str)
+    const isPascalCase = (str: string) => testPascalCase(str)
     const toPascalCase = (str: string) => {
       return str
         .replace(new RegExp(/[-_]+/, 'g'), ' ')

--- a/tests/lib/rules/prefer-pascal-case.test.ts
+++ b/tests/lib/rules/prefer-pascal-case.test.ts
@@ -20,6 +20,7 @@ import ruleTester from '../../utils/rule-tester'
 ruleTester.run('prefer-pascal-case', rule, {
   valid: [
     'export const Primary = {}',
+    'export const 测试 = {}',
     `export const __namedExportsOrder = ['Secondary', 'Primary']`,
     `export const _primary = {}`,
     'export const Primary: Story = {}',


### PR DESCRIPTION
## What Changed

Change `isPascalCase` method in the rule `prefer-pascal-case`. Some codes are copied from https://github.com/jsx-eslint/eslint-plugin-react/blob/161317e664ff00e0c0a27f3d032613f621c05939/lib/rules/jsx-pascal-case.js

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
