### PR TITLE
feat: allow ignore option in no-uninstalled-addons

### DIFF
--- a/docs/rules/no-uninstalled-addons.md
+++ b/docs/rules/no-uninstalled-addons.md
@@ -8,11 +8,11 @@
 
 ## Rule Details
 
-This rule checks if all addons registered in `.storybook/main.js` are properly listed in the root package.json of your project.
+This rule checks if all addons registered in `.storybook/main.js` are properly listed in the root `package.json` of your project.
 
-For instance, if the `@storybook/addon-links` is in the `.storybook/main.js` but is not listed in the `package.json` of the project, this rule will notify the user to add the addon to the package.json and install it.
+For instance, if the `@storybook/addon-links` is in the `.storybook/main.js` but is not listed in the `package.json` of the project, this rule will notify the user to add the addon to the `package.json` and install it.
 
-As an important side note, this rule will check for the `package.json` in the **root level** of your project. You can customize the location of the `package.json` by [setting the `packageJsonPath` option](#configure).
+As an important side note, this rule will check for the `package.json` in the **root level** of your project. You can customize the location of the `package.json` by [setting the `packageJsonLocation` option](#configure).
 
 Another very important side note: your ESLint config must allow the linting of the `.storybook` folder. By default, ESLint ignores all dot-files so this folder will be ignored. In order to allow this rule to lint the `.storybook/main.js` file, it's important to configure ESLint to lint this file. This can be achieved by writing something like:
 
@@ -68,7 +68,9 @@ module.exports = {
 
 ### Configure
 
-This rule assumes that the `package.json` is located in the root of your project. You can customize this by setting the `packageJsonPath` option of the rule:
+#### `packageJsonLocation`
+
+This rule assumes that the `package.json` is located in the root of your project. You can customize this by setting the `packageJsonLocation` option of the rule:
 
 ```js
 module.exports = {
@@ -79,6 +81,21 @@ module.exports = {
 ```
 
 Note that the path must be relative to where ESLint runs from, which is usually relative to the root of the project.
+
+#### `ignore`
+
+You can also ignore certain addons by providing an ignore array in the options:
+
+```js
+module.exports = {
+  rules: {
+    'storybook/no-uninstalled-addons': [
+      'error',
+      { packageJsonLocation: './folder/package.json', ignore: ['custom-addon'] },
+    ],
+  },
+}
+```
 
 ### What if I use a different storybook config directory?
 
@@ -103,4 +120,4 @@ This rule is very handy to be used because if the user tries to start storybook 
 
 ## Further Reading
 
-Check the issue in GitHub: https://github.com/storybookjs/eslint-plugin-storybook/issues/95
+Check the issue in GitHub: [https://github.com/storybookjs/eslint-plugin-storybook/issues/95](https://github.com/storybookjs/eslint-plugin-storybook/issues/95)

--- a/tests/lib/rules/no-uninstalled-addons.test.ts
+++ b/tests/lib/rules/no-uninstalled-addons.test.ts
@@ -11,7 +11,7 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils'
 
 import rule from '../../../lib/rules/no-uninstalled-addons'
 import ruleTester from '../../utils/rule-tester'
-import { sep } from 'path';
+import { sep } from 'path'
 
 jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
@@ -118,6 +118,24 @@ ruleTester.run('no-uninstalled-addons', rule, {
         ]
       }
   `,
+    {
+      code: `
+      module.exports = {
+          addons: [
+            "@storybook/addon-links",
+            "@storybook/addon-essentials",
+            "@storybook/addon-interactions",
+            "@storybook/not-installed-addon"
+          ]
+        }
+    `,
+      options: [
+        {
+          packageJsonLocation: '',
+          ignore: ['@storybook/addon-not-installed-addon'],
+        },
+      ],
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-uninstalled-addons.test.ts
+++ b/tests/lib/rules/no-uninstalled-addons.test.ts
@@ -125,14 +125,14 @@ ruleTester.run('no-uninstalled-addons', rule, {
             "@storybook/addon-links",
             "@storybook/addon-essentials",
             "@storybook/addon-interactions",
-            "@storybook/not-installed-addon"
+            "@storybook/not-installed-addon",
           ]
         }
     `,
       options: [
         {
           packageJsonLocation: '',
-          ignore: ['@storybook/addon-not-installed-addon'],
+          ignore: ['@storybook/not-installed-addon'],
         },
       ],
     },


### PR DESCRIPTION
Issue: #

## What Changed

Added the `ignore` option in the `no-uninstalled-addons` rule.

## Checklist

Check the ones applicable to your change:

- [x] Ran `yarn update-all`
- [x] Tests are updated
- [x] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [x] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
