### PR TITLE
Remove uninformative 'Further Reading' sections from rule docs

### DIFF
--- a/docs/rules/meta-inline-properties.md
+++ b/docs/rules/meta-inline-properties.md
@@ -29,7 +29,3 @@ export default {
   component: Button,
 }
 ```
-
-## Further Reading
-
-If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/docs/rules/use-storybook-expect.md
+++ b/docs/rules/use-storybook-expect.md
@@ -34,7 +34,3 @@ Default.play = () => {
 ## When Not To Use It
 
 This rule should not be applied in test files. Please ensure you are defining the storybook rules only for story files. You can see more details [here](https://github.com/storybookjs/eslint-plugin-storybook#eslint-overrides).
-
-## Further Reading
-
-If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/docs/rules/use-storybook-testing-library.md
+++ b/docs/rules/use-storybook-testing-library.md
@@ -36,7 +36,3 @@ Default.play = async (context) => {
 ## When Not To Use It
 
 This rule should not be applied in test files. Please ensure you are defining the storybook rules only for story files. You can see more details [here](https://github.com/storybookjs/eslint-plugin-storybook#eslint-overrides).
-
-## Further Reading
-
-If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. Don't forget to run `yarn update-all` to update configuration files and their documentation! -->

Some of the rules have a 'Further Reading' section that don't provide any additional reading materials. I simply removed them in this PR.

I considered modifying the template in generate-rule.ts too, but I can't think of a good way to do it since the writer will have to manually delete the section header anyway, if they have nothing to write for a given optional section.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [ ] Tests are updated
- [x] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
