### PR TITLE
use-storybook-expect: allow storybook/test imports

### DIFF
--- a/lib/rules/use-storybook-expect.ts
+++ b/lib/rules/use-storybook-expect.ts
@@ -45,8 +45,11 @@ export = createStorybookRule<TDefaultOptions, string>({
     //----------------------------------------------------------------------
 
     const isExpectFromStorybookImported = (node: TSESTree.ImportDeclaration) => {
+      const { value: packageName } = node.source
+      const usesExpectFromStorybook =
+        packageName === '@storybook/jest' || packageName === '@storybook/test'
       return (
-        node.source.value === '@storybook/jest' &&
+        usesExpectFromStorybook &&
         node.specifiers.find((spec) => isImportSpecifier(spec) && spec.imported.name === 'expect')
       )
     }

--- a/tests/lib/rules/use-storybook-expect.test.ts
+++ b/tests/lib/rules/use-storybook-expect.test.ts
@@ -36,6 +36,23 @@ ruleTester.run('use-storybook-expect', rule, {
         },
       };
     `,
+    dedent`
+      import { expect } from '@storybook/test';
+
+      Default.play = () => {
+        expect(123).toEqual(123);
+      }
+    `,
+    dedent`
+      import { expect } from '@storybook/test';
+
+      export const Basic = {
+        ...Default,
+        play: async (context) => {
+          expect(123).toEqual(123);
+        },
+      };
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
## What Changed

This PR allows imports from `@storybook/test`, an experimental package that provides similar utilities than `@storybook/jest`.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated
