### PR TITLE
#132 await interactions false positive issue

### DIFF
--- a/lib/rules/await-interactions.ts
+++ b/lib/rules/await-interactions.ts
@@ -76,6 +76,16 @@ export = createStorybookRule({
       if (
         isMemberExpression(expr.callee) &&
         isIdentifier(expr.callee.object) &&
+        isIdentifier(expr.callee.property) &&
+        expr.callee.object.name === 'userEvent' &&
+        expr.callee.property.name === 'setup'
+      ) {
+        return null
+      }
+
+      if (
+        isMemberExpression(expr.callee) &&
+        isIdentifier(expr.callee.object) &&
         shouldAwait(expr.callee.object.name)
       ) {
         return expr.callee.object

--- a/tests/lib/rules/await-interactions.test.ts
+++ b/tests/lib/rules/await-interactions.test.ts
@@ -110,6 +110,14 @@ ruleTester.run('await-interactions', rule, {
         }
       }
     `,
+    dedent`
+      export const Story = {
+        play: async ({canvasElement}) => {
+          const user = userEvent.setup();
+          await user.click(button);
+        },
+      };
+    `,
   ],
   invalid: [
     {
@@ -370,6 +378,53 @@ ruleTester.run('await-interactions', rule, {
           messageId: 'interactionShouldBeAwaited',
           data: { method: 'play' },
         },
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'play' },
+        },
+      ],
+    },
+    {
+      code: dedent`
+        export const Story = {
+          play: async ({canvasElement}) => {
+            const user = await userEvent.setup();
+          },
+        };
+      `,
+      output: dedent`
+      export const Story = {
+        play: async ({canvasElement}) => {
+          const user = userEvent.setup();
+        },
+      };
+      `,
+      errors: [
+        {
+          // @ts-ignore
+          messageId: 'setupShouldNotBeAwaited',
+          data: { method: 'play' },
+        },
+      ],
+    },
+    {
+      code: dedent`
+        export const Story = {
+          play: async ({canvasElement}) => {
+            const user = userEvent.setup();
+            user.click(button);
+          },
+        };
+      `,
+      output: dedent`
+        export const Story = {
+          play: async ({canvasElement}) => {
+            const user = userEvent.setup();
+            await user.click(button);
+          },
+        };
+      `,
+      errors: [
         {
           messageId: 'interactionShouldBeAwaited',
           data: { method: 'play' },


### PR DESCRIPTION
# Issue: #132 

## What Changed

- [x] [It does not expect `await` before `userEvent.setup()` call.](https://github.com/storybookjs/eslint-plugin-storybook/pull/142/files#diff-5e5eabedd8fb0017ac5bbc73ac08c4021e5edb36a8ffc2ede23599ace551d69cR398)
- [ ] [Does expect `await` before any call of method on object created by `userEvent.setup()` call.](https://github.com/storybookjs/eslint-plugin-storybook/pull/142/files#diff-5e5eabedd8fb0017ac5bbc73ac08c4021e5edb36a8ffc2ede23599ace551d69cR423)

<!-- Insert a description below. Don't forget to run `yarn update-all` to update configuration files and their documentation! -->

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
