### PR TITLE
Disable rule of hooks in stories files

### DIFF
--- a/lib/configs/addon-interactions.ts
+++ b/lib/configs/addon-interactions.ts
@@ -9,6 +9,7 @@ export = {
     {
       files: ['*.stories.@(ts|tsx|js|jsx|mjs|cjs)', '*.story.@(ts|tsx|js|jsx|mjs|cjs)'],
       rules: {
+        'react-hooks/rules-of-hooks': 'off',
         'import/no-anonymous-default-export': 'off',
         'storybook/await-interactions': 'error',
         'storybook/context-in-play-function': 'error',

--- a/lib/configs/csf-strict.ts
+++ b/lib/configs/csf-strict.ts
@@ -6,6 +6,7 @@
 export = {
   extends: require.resolve('./csf'),
   rules: {
+    'react-hooks/rules-of-hooks': 'off',
     'import/no-anonymous-default-export': 'off',
     'storybook/no-stories-of': 'error',
     'storybook/no-title-property-in-meta': 'error',

--- a/lib/configs/csf.ts
+++ b/lib/configs/csf.ts
@@ -9,6 +9,7 @@ export = {
     {
       files: ['*.stories.@(ts|tsx|js|jsx|mjs|cjs)', '*.story.@(ts|tsx|js|jsx|mjs|cjs)'],
       rules: {
+        'react-hooks/rules-of-hooks': 'off',
         'import/no-anonymous-default-export': 'off',
         'storybook/csf-component': 'warn',
         'storybook/default-exports': 'error',

--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -9,6 +9,7 @@ export = {
     {
       files: ['*.stories.@(ts|tsx|js|jsx|mjs|cjs)', '*.story.@(ts|tsx|js|jsx|mjs|cjs)'],
       rules: {
+        'react-hooks/rules-of-hooks': 'off',
         'import/no-anonymous-default-export': 'off',
         'storybook/await-interactions': 'error',
         'storybook/context-in-play-function': 'error',


### PR DESCRIPTION
Closes: https://github.com/storybookjs/storybook/issues/21115

## What Changed

I chatted with @valentinpalkovic and we concluded that instead of writing an automigration adding code that in neither case looks "quite right", we considered maybe adding an exception to the config exposed by the plugin, which turns off the problems reported from `react-hooks` eslint plugin.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `yarn update-all`
- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.0--canary.149.b9dd4e1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install eslint-plugin-storybook@0.7.0--canary.149.b9dd4e1.0
  # or 
  yarn add eslint-plugin-storybook@0.7.0--canary.149.b9dd4e1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
