### PR TITLE
chore: Update the link for eslintignore doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ And finally, add this to your `.eslintignore` file:
 
 This allows for this plugin to also lint your configuration files inside the .storybook folder, so that you always have a correct configuration and don't face any issues regarding mistyped addon names, for instance.
 
-> For more info on why this line is required in the .eslintignore file, check this [ESLint documentation](https://eslint.org/docs/latest/user-guide/configuring/ignoring-code#:~:text=In%20addition%20to,contents%2C%20are%20ignored).
+> For more info on why this line is required in the .eslintignore file, check this [ESLint documentation](https://eslint.org/docs/latest/use/configure/ignore-deprecated#:~:text=In%20addition%20to,contents%20are%20ignored).
 
 ## Usage
 

--- a/docs/rules/no-uninstalled-addons.md
+++ b/docs/rules/no-uninstalled-addons.md
@@ -21,7 +21,7 @@ Another very important side note: your ESLint config must allow the linting of t
 !.storybook
 ```
 
-For more info, check this [ESLint documentation](https://eslint.org/docs/latest/user-guide/configuring/ignoring-code#:~:text=In%20addition%20to,contents%2C%20are%20ignored).
+For more info, check this [ESLint documentation](https://eslint.org/docs/latest/use/configure/ignore-deprecated#:~:text=In%20addition%20to,contents%20are%20ignored).
 
 Examples of **incorrect** code for this rule:
 


### PR DESCRIPTION
## What Changed

Since the `.eslintignore` documentation has been moved from https://eslint.org/docs/latest/user-guide/configuring/ignoring-code to https://eslint.org/docs/latest/use/configure/ignore-deprecated, I have updated README and `no-uninstalled-addons.md` accordingly.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `pnpm run update-all`
- [ ] Tests are updated
- [x] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
