### PR TITLE
use-storybook-expect: remove auto fix suggestion

### DIFF
--- a/lib/rules/use-storybook-expect.ts
+++ b/lib/rules/use-storybook-expect.ts
@@ -26,14 +26,14 @@ export = createStorybookRule<TDefaultOptions, string>({
     hasSuggestions: true,
     schema: [],
     docs: {
-      description: 'Use expect from `@storybook/jest`',
+      description: 'Use expect from `@storybook/test` or `@storybook/jest`',
       categories: [CategoryId.ADDON_INTERACTIONS, CategoryId.RECOMMENDED],
       recommended: 'error',
     },
     messages: {
       updateImports: 'Update imports',
       useExpectFromStorybook:
-        'Do not use expect from jest directly in the story. You should use from `@storybook/jest` instead.',
+        'Do not use global expect directly in the story. You should import it from `@storybook/test` or `@storybook/jest` instead.',
     },
   },
 
@@ -82,23 +82,6 @@ export = createStorybookRule<TDefaultOptions, string>({
             context.report({
               node,
               messageId: 'useExpectFromStorybook',
-              fix: function (fixer) {
-                return fixer.insertTextAfterRange(
-                  [0, 0],
-                  "import { expect } from '@storybook/jest';\n"
-                )
-              },
-              suggest: [
-                {
-                  messageId: 'updateImports',
-                  fix: function (fixer) {
-                    return fixer.insertTextAfterRange(
-                      [0, 0],
-                      "import { expect } from '@storybook/jest';\n"
-                    )
-                  },
-                },
-              ],
             })
           })
         }

--- a/tests/lib/rules/use-storybook-expect.test.ts
+++ b/tests/lib/rules/use-storybook-expect.test.ts
@@ -62,27 +62,10 @@ ruleTester.run('use-storybook-expect', rule, {
           expect(123).toEqual(123);
         }
       `,
-      output: dedent`
-        import { expect } from '@storybook/jest';
-        Default.play = () => {
-          expect(123).toEqual(123);
-        }
-      `,
       errors: [
         {
           messageId: 'useExpectFromStorybook',
           type: AST_NODE_TYPES.Identifier,
-          suggestions: [
-            {
-              messageId: 'updateImports',
-              output: dedent`
-                import { expect } from '@storybook/jest';
-                Default.play = () => {
-                  expect(123).toEqual(123);
-                }
-              `,
-            },
-          ],
         },
       ],
     },
@@ -93,29 +76,10 @@ ruleTester.run('use-storybook-expect', rule, {
         }
         Default.play = someInteraction
       `,
-      output: dedent`
-        import { expect } from '@storybook/jest';
-        const someInteraction = () => {
-          expect(123).toEqual(123);
-        }
-        Default.play = someInteraction
-      `,
       errors: [
         {
           messageId: 'useExpectFromStorybook',
           type: AST_NODE_TYPES.Identifier,
-          suggestions: [
-            {
-              messageId: 'updateImports',
-              output: dedent`
-                import { expect } from '@storybook/jest';
-                const someInteraction = () => {
-                  expect(123).toEqual(123);
-                }
-                Default.play = someInteraction
-              `,
-            },
-          ],
         },
       ],
     },
@@ -128,33 +92,10 @@ ruleTester.run('use-storybook-expect', rule, {
           },
         };
       `,
-      output: dedent`
-        import { expect } from '@storybook/jest';
-        export const Basic = {
-          ...Default,
-          play: async (context) => {
-            expect(123).toEqual(123);
-          },
-        };
-      `,
       errors: [
         {
           messageId: 'useExpectFromStorybook',
           type: AST_NODE_TYPES.Identifier,
-          suggestions: [
-            {
-              messageId: 'updateImports',
-              output: dedent`
-                import { expect } from '@storybook/jest';
-                export const Basic = {
-                  ...Default,
-                  play: async (context) => {
-                    expect(123).toEqual(123);
-                  },
-                };
-              `,
-            },
-          ],
         },
       ],
     },


### PR DESCRIPTION
Issue: #

## What Changed

In favor of the existence of `@storybook/test`, the use-storybook-expect rule removes the auto fix where it would add imports from `@storybook/jest`.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `pnpm run update-all`
- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
