### PR TITLE
add support for @storybook/test in await-interactions rule

### DIFF
--- a/lib/rules/await-interactions.ts
+++ b/lib/rules/await-interactions.ts
@@ -132,7 +132,7 @@ export = createStorybookRule({
 
     const isUserEventFromStorybookImported = (node: TSESTree.ImportDeclaration) => {
       return (
-        node.source.value === '@storybook/testing-library' &&
+        ['@storybook/test', '@storybook/testing-library'].includes(node.source.value) &&
         node.specifiers.find(
           (spec) =>
             isImportSpecifier(spec) &&
@@ -144,7 +144,7 @@ export = createStorybookRule({
 
     const isExpectFromStorybookImported = (node: TSESTree.ImportDeclaration) => {
       return (
-        node.source.value === '@storybook/jest' &&
+        ['@storybook/test', '@storybook/jest'].includes(node.source.value) &&
         node.specifiers.find(
           (spec) => isImportSpecifier(spec) && spec.imported.name === 'expect'
         ) !== undefined

--- a/tests/lib/rules/await-interactions.test.ts
+++ b/tests/lib/rules/await-interactions.test.ts
@@ -136,6 +136,60 @@ ruleTester.run('await-interactions', rule, {
     },
     {
       code: dedent`
+        import { expect } from '@storybook/test'
+        WithModalOpen.play = async ({ args }) => {
+          // should complain
+          expect(args.onClick).toHaveBeenCalled()
+        }
+      `,
+      output: dedent`
+        import { expect } from '@storybook/test'
+        WithModalOpen.play = async ({ args }) => {
+          // should complain
+          await expect(args.onClick).toHaveBeenCalled()
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'toHaveBeenCalled' },
+        },
+      ],
+    },
+    {
+      code: dedent`
+				import { userEvent } from '@storybook/test'
+
+        WithModalOpen.play = async ({ canvasElement }) => {
+          const canvas = within(canvasElement)
+
+          const foodItem = canvas.findByText(/Cheeseburger/i)
+          userEvent.click(foodItem)
+        }
+      `,
+      output: dedent`
+				import { userEvent } from '@storybook/test'
+
+        WithModalOpen.play = async ({ canvasElement }) => {
+          const canvas = within(canvasElement)
+
+          const foodItem = await canvas.findByText(/Cheeseburger/i)
+          await userEvent.click(foodItem)
+        }
+      `,
+      errors: [
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'findByText' },
+        },
+        {
+          messageId: 'interactionShouldBeAwaited',
+          data: { method: 'userEvent' },
+        },
+      ],
+    },
+    {
+      code: dedent`
         WithModalOpen.play = ({ canvasElement }) => {
           const canvas = within(canvasElement)
 


### PR DESCRIPTION
Issue: #168 

## What Changed

`await-interactions` is now supported importing `expect` and `userEvent` from `@storybook/test`

## Checklist

Check the ones applicable to your change:

- [ ] Ran `pnpm run update-all`
- [x] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
