### PR TITLE
default-exports: Refactor rule to handle meta declaration

### DIFF
--- a/docs/rules/default-exports.md
+++ b/docs/rules/default-exports.md
@@ -20,6 +20,17 @@ export const Primary = {}
 Examples of **correct** code for this rule:
 
 ```js
+const meta = {
+  title: 'Button',
+  args: { primary: true },
+  component: Button,
+}
+export const meta
+
+export const Primary = {}
+```
+
+```js
 export default {
   title: 'Button',
   args: { primary: true },

--- a/tests/lib/rules/default-exports.test.ts
+++ b/tests/lib/rules/default-exports.test.ts
@@ -48,7 +48,10 @@ ruleTester.run('default-exports', rule, {
           suggestions: [
             {
               messageId: 'fixSuggestion',
-              output: 'export default {}\nexport const Primary = () => <button>hello</button>',
+              output: dedent`
+                export default {}
+                export const Primary = () => <button>hello</button>
+              `,
             },
           ],
         },
@@ -70,8 +73,11 @@ ruleTester.run('default-exports', rule, {
           suggestions: [
             {
               messageId: 'fixSuggestion',
-              output:
-                "import { MyComponent, Foo } from './MyComponent'\nexport default { component: MyComponent }\nexport const Primary = () => <button>hello</button>",
+              output: dedent`
+                import { MyComponent, Foo } from './MyComponent'
+                export default { component: MyComponent }
+                export const Primary = () => <button>hello</button>
+              `,
             },
           ],
         },
@@ -93,8 +99,11 @@ ruleTester.run('default-exports', rule, {
           suggestions: [
             {
               messageId: 'fixSuggestion',
-              output:
-                "import MyComponent from './MyComponent'\nexport default { component: MyComponent }\nexport const Primary = () => <button>hello</button>",
+              output: dedent`
+                import MyComponent from './MyComponent'
+                export default { component: MyComponent }
+                export const Primary = () => <button>hello</button>
+                `,
             },
           ],
         },
@@ -116,8 +125,39 @@ ruleTester.run('default-exports', rule, {
           suggestions: [
             {
               messageId: 'fixSuggestion',
-              output:
-                "import { MyComponentProps } from './MyComponent'\nexport default {}\nexport const Primary = () => <button>hello</button>",
+              output: dedent`
+                import { MyComponentProps } from './MyComponent'
+                export default {}
+                export const Primary = () => <button>hello</button>`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { MyComponentProps } from './MyComponent';
+        export const Primary = () => <button>hello</button>;
+        const meta = { args: { foo: 'bar' } };
+      `,
+      output: dedent`
+        import { MyComponentProps } from './MyComponent';
+        export const Primary = () => <button>hello</button>;
+        const meta = { args: { foo: 'bar' } };
+        export default meta;
+      `,
+      errors: [
+        {
+          messageId: 'shouldHaveDefaultExport',
+          suggestions: [
+            {
+              messageId: 'fixSuggestion',
+              output: dedent`
+                import { MyComponentProps } from './MyComponent';
+                export const Primary = () => <button>hello</button>;
+                const meta = { args: { foo: 'bar' } };
+                export default meta;
+              `,
             },
           ],
         },


### PR DESCRIPTION
Issue: #

## What Changed

The default-exports rule now supports auto-adding export default when users have only typed:
```ts
const meta = {}
```

so it will become
```ts
const meta = {}
export default meta
```

## Checklist

Check the ones applicable to your change:

- [ ] Ran `pnpm run update-all`
- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
