### PR TITLE
Type configs using literal types

### DIFF
--- a/lib/configs/addon-interactions.ts
+++ b/lib/configs/addon-interactions.ts
@@ -15,13 +15,13 @@ export = {
         'storybook/context-in-play-function': 'error',
         'storybook/use-storybook-expect': 'error',
         'storybook/use-storybook-testing-library': 'error',
-      },
+      } as const,
     },
     {
       files: ['.storybook/main.@(js|cjs|mjs|ts)'],
       rules: {
         'storybook/no-uninstalled-addons': 'error',
-      },
+      } as const,
     },
   ],
 }

--- a/lib/configs/csf-strict.ts
+++ b/lib/configs/csf-strict.ts
@@ -10,5 +10,5 @@ export = {
     'import/no-anonymous-default-export': 'off',
     'storybook/no-stories-of': 'error',
     'storybook/no-title-property-in-meta': 'error',
-  },
+  } as const,
 }

--- a/lib/configs/csf.ts
+++ b/lib/configs/csf.ts
@@ -16,13 +16,13 @@ export = {
         'storybook/hierarchy-separator': 'warn',
         'storybook/no-redundant-story-name': 'warn',
         'storybook/story-exports': 'error',
-      },
+      } as const,
     },
     {
       files: ['.storybook/main.@(js|cjs|mjs|ts)'],
       rules: {
         'storybook/no-uninstalled-addons': 'error',
-      },
+      } as const,
     },
   ],
 }

--- a/lib/configs/flat/addon-interactions.ts
+++ b/lib/configs/flat/addon-interactions.ts
@@ -23,13 +23,13 @@ export = [
       'storybook/context-in-play-function': 'error',
       'storybook/use-storybook-expect': 'error',
       'storybook/use-storybook-testing-library': 'error',
-    },
+    } as const,
   },
   {
     name: 'storybook:addon-interactions:main-rules',
     files: ['.storybook/main.@(js|cjs|mjs|ts)'],
     rules: {
       'storybook/no-uninstalled-addons': 'error',
-    },
+    } as const,
   },
 ]

--- a/lib/configs/flat/csf-strict.ts
+++ b/lib/configs/flat/csf-strict.ts
@@ -14,6 +14,6 @@ export = [
       'import/no-anonymous-default-export': 'off',
       'storybook/no-stories-of': 'error',
       'storybook/no-title-property-in-meta': 'error',
-    },
+    } as const,
   },
 ]

--- a/lib/configs/flat/csf.ts
+++ b/lib/configs/flat/csf.ts
@@ -24,13 +24,13 @@ export = [
       'storybook/hierarchy-separator': 'warn',
       'storybook/no-redundant-story-name': 'warn',
       'storybook/story-exports': 'error',
-    },
+    } as const,
   },
   {
     name: 'storybook:csf:main-rules',
     files: ['.storybook/main.@(js|cjs|mjs|ts)'],
     rules: {
       'storybook/no-uninstalled-addons': 'error',
-    },
+    } as const,
   },
 ]

--- a/lib/configs/flat/recommended.ts
+++ b/lib/configs/flat/recommended.ts
@@ -28,13 +28,13 @@ export = [
       'storybook/story-exports': 'error',
       'storybook/use-storybook-expect': 'error',
       'storybook/use-storybook-testing-library': 'error',
-    },
+    } as const,
   },
   {
     name: 'storybook:recommended:main-rules',
     files: ['.storybook/main.@(js|cjs|mjs|ts)'],
     rules: {
       'storybook/no-uninstalled-addons': 'error',
-    },
+    } as const,
   },
 ]

--- a/lib/configs/recommended.ts
+++ b/lib/configs/recommended.ts
@@ -20,13 +20,13 @@ export = {
         'storybook/story-exports': 'error',
         'storybook/use-storybook-expect': 'error',
         'storybook/use-storybook-testing-library': 'error',
-      },
+      } as const,
     },
     {
       files: ['.storybook/main.@(js|cjs|mjs|ts)'],
       rules: {
         'storybook/no-uninstalled-addons': 'error',
-      },
+      } as const,
     },
   ],
 }

--- a/tools/utils/updates.ts
+++ b/tools/utils/updates.ts
@@ -22,13 +22,13 @@ export function formatRules(rules: TCategory['rules'], exclude?: string[]) {
     { ...externalRuleOverrides }
   )
 
-  return JSON.stringify(obj, null, 2)
+  return JSON.stringify(obj, null, 2) + ' as const'
 }
 
 export function formatSingleRule(rules: TCategory['rules'], ruleId: string) {
   const ruleOpt = rules.find((rule) => rule.ruleId === ruleId)?.meta.severity || 'error'
 
-  return JSON.stringify({ [ruleId]: ruleOpt }, null, 2)
+  return JSON.stringify({ [ruleId]: ruleOpt }, null, 2) + ' as const'
 }
 
 export const SUPPORTED_EXTENSIONS = ['ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs']


### PR DESCRIPTION

Issue: #181

## What Changed

By using `as const` on the string values for each of the rule configs, we ensure that the generated rules have string literal types matching their configured values. This allows it to satisfy the types required by the ESLint config type, which requires `'error' | 'warn' | 'off' | ...`


## Checklist

Check the ones applicable to your change:

- [x] Ran `pnpm run update-all`
- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
