### PR TITLE
docs: typo in flat config setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you are using [flat config style](https://eslint.org/docs/latest/use/configur
 export default [
   // ...
   {
-    // Inside your .eslintignore file
+    // Inside your flat config file
     ignores: ['!.storybook'],
   },
 ]


### PR DESCRIPTION
## What Changed
Updated flat config setup instructions. The instruction itself seems to work fine but a comment might be misleading - it references `.eslintignore` while one's editing a flat config file.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `pnpm run update-all`
- [ ] Tests are updated
- [X] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [X] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
