### PR TITLE
fix(peer-deps): update eslint version range to `>=8`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ export default [
 ]
 ```
 
+## ESLint compatibility
+
+Use the following table to use the correct version of this package, based on the version of ESLint you're using:
+
+| ESLint version | Storybook plugin version |
+| -------------- | ------------------------ |
+| ^9.0.0         | ^0.10.0                  |
+| ^8.57.0        | ^0.10.0                  |
+| ^7.0.0         | ~0.9.0                   |
+
 ## Usage
 
 ### Configuration (`.eslintrc`)

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "eslint": ">=6"
+    "eslint": ">=8"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
Issue: #185 

## What Changed

<!-- Insert a description below. Don't forget to run `pnpm run update-all` to update configuration files and their documentation! -->
Updates the peer dependency version range for `eslint`.

## Checklist

Check the ones applicable to your change:

- [x] Ran `pnpm run update-all`
- [x] Tests are updated
- [x] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
