### PR TITLE
docs: Explicitly mention flat config for findability

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Optionally, you can override, add or disable rules settings. You likely don't wa
 
 ### Configuration (`eslint.config.[c|m]?js`)
 
-Use `eslint.config.[c|m]?js` file to configure rules. This is the default in ESLint v9, but can be used starting from ESLint v8.57.0. See also: https://eslint.org/docs/latest/use/configure/configuration-files-new.
+Use `eslint.config.[c|m]?js` file to configure rules using the [flat config style](https://eslint.org/docs/latest/use/configure/configuration-files-new). This is the default in ESLint v9, but can be used starting from ESLint v8.57.0. See also: https://eslint.org/docs/latest/use/configure/configuration-files-new.
 
 ```js
 import storybook from 'eslint-plugin-storybook'


### PR DESCRIPTION
No linked issue.

## What Changed

**This PR adds an explicit mention of "flat config" in the flat config section.**

### Why?

I often search for 'flat config' when taking over a project and having to decide if it's ready to upgrade to ESLint 9. When I looked at this plugin today, I parsed the README quickly and initially missed the flat config section. I had to check the dependencies to see that it supports ESLint 9.

Many major ESLint plugins use the word flat somewhere in their description of this new config:
* https://typescript-eslint.io/getting-started/
* https://www.npmjs.com/package/eslint-plugin-prettier
* https://www.npmjs.com/package/eslint-plugin-import
* https://www.npmjs.com/package/eslint-plugin-turbo
* https://eslint.vuejs.org/user-guide/

The ones that don't:
* https://nextjs.org/docs/app/api-reference/config/eslint doesn't yet support it but gives FlatCompat examples
* https://www.npmjs.com/package/eslint-config-airbnb doesn't yet support it

Using the explicit wording in the relevant section ensures a ^+F search finds a match, since **not finding anything** when searching for "flat" could lead users to **wrongly assume that ESLint 9 is not supported**.

## Checklist

Check the ones applicable to your change:

- [ ] ~Ran `pnpm run update-all`~
- [ ] ~Tests are updated~
- [x] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [x] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`
