### PR TITLE
fix: allows self-referencing context in play function

### DIFF
--- a/docs/rules/context-in-play-function.md
+++ b/docs/rules/context-in-play-function.md
@@ -50,6 +50,18 @@ MyStory.play = (context) => {
 }
 ```
 
+```js
+import { within, userEvent } from '@storybook/testing-library'
+
+MyStory.play = ({ context, canvasElement }) => {
+  const canvas = within(canvasElement)
+  // passing self referencing context property 👍
+  await MyOtherStory.play(context)
+
+  await userEvent.click(canvas.getByRole('button'))
+}
+```
+
 ## When Not To Use It
 
 This rule should not be applied in test files. Please ensure you are defining the storybook rules only for story files. You can see more details [here](https://github.com/storybookjs/eslint-plugin-storybook#overridingdisabling-rules).

--- a/lib/rules/context-in-play-function.ts
+++ b/lib/rules/context-in-play-function.ts
@@ -87,6 +87,18 @@ export = createStorybookRule({
           return param.name
         }
         if (isObjectPattern(param)) {
+          if (
+            param.properties.find((prop) => {
+              return (
+                prop.type === 'Property' &&
+                prop.key.type === 'Identifier' &&
+                prop.key.name === 'context'
+              )
+            })
+          ) {
+            return 'context'
+          }
+
           const restElement = param.properties.find(isRestElement)
           if (!restElement || !isIdentifier(restElement.argument)) {
             // No rest element found

--- a/tests/lib/rules/context-in-play-function.test.ts
+++ b/tests/lib/rules/context-in-play-function.test.ts
@@ -72,6 +72,13 @@ ruleTester.run('context-in-play-function', rule, {
         }
       }
     `,
+    dedent`
+      export const SecondStory = {
+        play: async ({ context, canvasElement }) => {
+          await FirstStory.play(context)
+        }
+      }
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
Issue: #162

## What Changed
Added checks for self-referencing properties.
<!-- Insert a description below. Don't forget to run `pnpm run update-all` to update configuration files and their documentation! -->

## Checklist

Check the ones applicable to your change:

- [ ] Ran `pnpm run update-all`
- [x] Tests are updated
- [x] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
