### PR TITLE
fix(peer-deps): Add support for typescript 5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,11 +82,11 @@
     "ts-jest": "^29.1.2",
     "ts-migrate": "^0.1.35",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.8.0"
   },
   "peerDependencies": {
     "eslint": ">=8",
-    "typescript": ">=4.8.4 <5.8.0"
+    "typescript": ">=4.8.4 <5.9.0"
   },
   "engines": {
     "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
     "typescript": "^5.8.0"
   },
   "peerDependencies": {
-    "eslint": ">=8",
-    "typescript": ">=4.8.4 <5.9.0"
+    "eslint": ">=8"
   },
   "engines": {
     "node": ">= 18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,14 +13,14 @@ importers:
         version: 0.1.11
       '@typescript-eslint/utils':
         specifier: ^8.8.1
-        version: 8.8.1(eslint@8.57.1)(typescript@5.4.5)
+        version: 8.8.1(eslint@8.57.1)(typescript@5.8.2)
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0
     devDependencies:
       '@auto-it/released':
         specifier: ^11.2.1
-        version: 11.2.1(@types/node@18.19.17)(typescript@5.4.5)
+        version: 11.2.1(@types/node@18.19.17)(typescript@5.8.2)
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.2
@@ -38,16 +38,16 @@ importers:
         version: 7.5.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.8.1
-        version: 8.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.4.5))(eslint@8.57.1)(typescript@5.4.5)
+        version: 8.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/parser':
         specifier: ^8.8.1
-        version: 8.8.1(eslint@8.57.1)(typescript@5.4.5)
+        version: 8.8.1(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/rule-tester':
         specifier: ^8.8.1
-        version: 8.8.1(eslint@8.57.1)(typescript@5.4.5)
+        version: 8.8.1(eslint@8.57.1)(typescript@5.8.2)
       auto:
         specifier: ^11.2.1
-        version: 11.2.1(@types/node@18.19.17)(typescript@5.4.5)
+        version: 11.2.1(@types/node@18.19.17)(typescript@5.8.2)
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -68,7 +68,7 @@ importers:
         version: 9.0.11
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))
       lint-staged:
         specifier: ^15.2.2
         version: 15.2.2
@@ -86,16 +86,16 @@ importers:
         version: 7.6.0
       ts-jest:
         specifier: ^29.1.2
-        version: 29.1.2(@babel/core@7.23.9)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.9))(jest@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.1.2(@babel/core@7.23.9)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.9))(jest@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2)))(typescript@5.8.2)
       ts-migrate:
         specifier: ^0.1.35
-        version: 0.1.35(@babel/preset-env@7.23.9(@babel/core@7.23.9))(typescript@5.4.5)
+        version: 0.1.35(@babel/preset-env@7.23.9(@babel/core@7.23.9))(typescript@5.8.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@18.19.17)(typescript@5.4.5)
+        version: 10.9.2(@types/node@18.19.17)(typescript@5.8.2)
       typescript:
-        specifier: ^5.4.5
-        version: 5.4.5
+        specifier: ^5.8.0
+        version: 5.8.2
 
 packages:
 
@@ -3380,8 +3380,8 @@ packages:
   typescript-memoize@1.1.1:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3563,10 +3563,10 @@ snapshots:
 
   '@auto-it/bot-list@11.2.1': {}
 
-  '@auto-it/core@11.2.1(@types/node@18.19.17)(typescript@5.4.5)':
+  '@auto-it/core@11.2.1(@types/node@18.19.17)(typescript@5.8.2)':
     dependencies:
       '@auto-it/bot-list': 11.2.1
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2(cosmiconfig@7.0.0)(typescript@5.4.5)
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2(cosmiconfig@7.0.0)(typescript@5.8.2)
       '@octokit/core': 3.6.0
       '@octokit/plugin-enterprise-compatibility': 1.3.0
       '@octokit/plugin-retry': 3.0.9
@@ -3600,10 +3600,10 @@ snapshots:
       tapable: 2.2.1
       terminal-link: 2.1.1
       tinycolor2: 1.6.0
-      ts-node: 10.9.2(@types/node@18.19.17)(typescript@5.4.5)
+      ts-node: 10.9.2(@types/node@18.19.17)(typescript@5.8.2)
       tslib: 2.1.0
       type-fest: 0.21.3
-      typescript: 5.4.5
+      typescript: 5.8.2
       typescript-memoize: 1.1.1
       url-join: 4.0.1
     optionalDependencies:
@@ -3614,9 +3614,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@auto-it/npm@11.2.1(@types/node@18.19.17)(typescript@5.4.5)':
+  '@auto-it/npm@11.2.1(@types/node@18.19.17)(typescript@5.8.2)':
     dependencies:
-      '@auto-it/core': 11.2.1(@types/node@18.19.17)(typescript@5.4.5)
+      '@auto-it/core': 11.2.1(@types/node@18.19.17)(typescript@5.8.2)
       '@auto-it/package-json-utils': 11.2.1
       await-to-js: 3.0.0
       endent: 2.1.0
@@ -3643,10 +3643,10 @@ snapshots:
       parse-author: 2.0.0
       parse-github-url: 1.0.2
 
-  '@auto-it/released@11.2.1(@types/node@18.19.17)(typescript@5.4.5)':
+  '@auto-it/released@11.2.1(@types/node@18.19.17)(typescript@5.8.2)':
     dependencies:
       '@auto-it/bot-list': 11.2.1
-      '@auto-it/core': 11.2.1(@types/node@18.19.17)(typescript@5.4.5)
+      '@auto-it/core': 11.2.1(@types/node@18.19.17)(typescript@5.8.2)
       deepmerge: 4.3.1
       fp-ts: 2.16.2
       io-ts: 2.2.21(fp-ts@2.16.2)
@@ -3659,9 +3659,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@auto-it/version-file@11.2.1(@types/node@18.19.17)(typescript@5.4.5)':
+  '@auto-it/version-file@11.2.1(@types/node@18.19.17)(typescript@5.8.2)':
     dependencies:
-      '@auto-it/core': 11.2.1(@types/node@18.19.17)(typescript@5.4.5)
+      '@auto-it/core': 11.2.1(@types/node@18.19.17)(typescript@5.8.2)
       fp-ts: 2.16.2
       io-ts: 2.2.21(fp-ts@2.16.2)
       semver: 7.6.0
@@ -4473,12 +4473,12 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2(cosmiconfig@7.0.0)(typescript@5.4.5)':
+  '@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2(cosmiconfig@7.0.0)(typescript@5.8.2)':
     dependencies:
       cosmiconfig: 7.0.0
       lodash.get: 4.4.2
       make-error: 1.3.6
-      ts-node: 9.1.1(typescript@5.4.5)
+      ts-node: 9.1.1(typescript@5.8.2)
       tslib: 2.6.2
     transitivePeerDependencies:
       - typescript
@@ -4561,7 +4561,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -4575,7 +4575,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4947,41 +4947,41 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.4.5))(eslint@8.57.1)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@8.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 8.8.1(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.8.1(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 8.8.1
-      '@typescript-eslint/type-utils': 8.8.1(eslint@8.57.1)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.8.1(eslint@8.57.1)(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.8.1
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.4.5)':
+  '@typescript-eslint/parser@8.8.1(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.8.1
       '@typescript-eslint/types': 8.8.1
-      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.8.2)
       '@typescript-eslint/visitor-keys': 8.8.1
       debug: 4.3.4
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.8.1(eslint@8.57.1)(typescript@5.4.5)':
+  '@typescript-eslint/rule-tester@8.8.1(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.8.2)
       ajv: 6.12.6
       eslint: 8.57.1
       json-stable-stringify-without-jsonify: 1.0.1
@@ -4996,21 +4996,21 @@ snapshots:
       '@typescript-eslint/types': 8.8.1
       '@typescript-eslint/visitor-keys': 8.8.1
 
-  '@typescript-eslint/type-utils@8.8.1(eslint@8.57.1)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@8.8.1(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.8.2)
+      '@typescript-eslint/utils': 8.8.1(eslint@8.57.1)(typescript@5.8.2)
       debug: 4.3.4
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.8.2
     transitivePeerDependencies:
       - eslint
       - supports-color
 
   '@typescript-eslint/types@8.8.1': {}
 
-  '@typescript-eslint/typescript-estree@8.8.1(typescript@5.4.5)':
+  '@typescript-eslint/typescript-estree@8.8.1(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 8.8.1
       '@typescript-eslint/visitor-keys': 8.8.1
@@ -5019,18 +5019,18 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.0
-      ts-api-utils: 1.3.0(typescript@5.4.5)
+      ts-api-utils: 1.3.0(typescript@5.8.2)
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.8.1(eslint@8.57.1)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.8.1(eslint@8.57.1)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.8.1
       '@typescript-eslint/types': 8.8.1
-      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.8.2)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -5152,12 +5152,12 @@ snapshots:
 
   author-regex@1.0.0: {}
 
-  auto@11.2.1(@types/node@18.19.17)(typescript@5.4.5):
+  auto@11.2.1(@types/node@18.19.17)(typescript@5.8.2):
     dependencies:
-      '@auto-it/core': 11.2.1(@types/node@18.19.17)(typescript@5.4.5)
-      '@auto-it/npm': 11.2.1(@types/node@18.19.17)(typescript@5.4.5)
-      '@auto-it/released': 11.2.1(@types/node@18.19.17)(typescript@5.4.5)
-      '@auto-it/version-file': 11.2.1(@types/node@18.19.17)(typescript@5.4.5)
+      '@auto-it/core': 11.2.1(@types/node@18.19.17)(typescript@5.8.2)
+      '@auto-it/npm': 11.2.1(@types/node@18.19.17)(typescript@5.8.2)
+      '@auto-it/released': 11.2.1(@types/node@18.19.17)(typescript@5.8.2)
+      '@auto-it/version-file': 11.2.1(@types/node@18.19.17)(typescript@5.8.2)
       await-to-js: 3.0.0
       chalk: 4.1.2
       command-line-application: 0.10.1
@@ -5474,13 +5474,13 @@ snapshots:
       jest-worker: 24.9.0
       throat: 4.1.0
 
-  create-jest@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5)):
+  create-jest@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -6237,16 +6237,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5)):
+  jest-cli@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))
+      create-jest: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -6256,7 +6256,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.23.9
       '@jest/test-sequencer': 29.7.0
@@ -6282,7 +6282,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.19.17
-      ts-node: 10.9.2(@types/node@18.19.17)(typescript@5.4.5)
+      ts-node: 10.9.2(@types/node@18.19.17)(typescript@5.8.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -6507,12 +6507,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5)):
+  jest@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))
+      jest-cli: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -7424,62 +7424,62 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-api-utils@1.3.0(typescript@5.4.5):
+  ts-api-utils@1.3.0(typescript@5.8.2):
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.8.2
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.1.2(@babel/core@7.23.9)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.9))(jest@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5)))(typescript@5.4.5):
+  ts-jest@29.1.2(@babel/core@7.23.9)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.23.9))(jest@29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@18.19.17)(ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.0
-      typescript: 5.4.5
+      typescript: 5.8.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.23.9
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.23.9)
 
-  ts-migrate-plugins@0.1.35(@babel/preset-env@7.23.9(@babel/core@7.23.9))(typescript@5.4.5):
+  ts-migrate-plugins@0.1.35(@babel/preset-env@7.23.9(@babel/core@7.23.9))(typescript@5.8.2):
     dependencies:
       eslint: 7.32.0
       jscodeshift: 0.13.1(@babel/preset-env@7.23.9(@babel/core@7.23.9))
       json-schema: 0.4.0
-      ts-migrate-server: 0.1.33(typescript@5.4.5)
-      typescript: 5.4.5
+      ts-migrate-server: 0.1.33(typescript@5.8.2)
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  ts-migrate-server@0.1.33(typescript@5.4.5):
+  ts-migrate-server@0.1.33(typescript@5.8.2):
     dependencies:
       '@ts-morph/bootstrap': 0.16.0
       pretty-ms: 7.0.1
-      typescript: 5.4.5
+      typescript: 5.8.2
       updatable-log: 0.2.0
 
-  ts-migrate@0.1.35(@babel/preset-env@7.23.9(@babel/core@7.23.9))(typescript@5.4.5):
+  ts-migrate@0.1.35(@babel/preset-env@7.23.9(@babel/core@7.23.9))(typescript@5.8.2):
     dependencies:
       create-jest-runner: 0.5.3
       json5: 2.2.3
       json5-writer: 0.1.8
-      ts-migrate-plugins: 0.1.35(@babel/preset-env@7.23.9(@babel/core@7.23.9))(typescript@5.4.5)
-      ts-migrate-server: 0.1.33(typescript@5.4.5)
-      typescript: 5.4.5
+      ts-migrate-plugins: 0.1.35(@babel/preset-env@7.23.9(@babel/core@7.23.9))(typescript@5.8.2)
+      ts-migrate-server: 0.1.33(typescript@5.8.2)
+      typescript: 5.8.2
       updatable-log: 0.2.0
       yargs: 15.4.1
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  ts-node@10.9.2(@types/node@18.19.17)(typescript@5.4.5):
+  ts-node@10.9.2(@types/node@18.19.17)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
@@ -7493,18 +7493,18 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.4.5
+      typescript: 5.8.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@9.1.1(typescript@5.4.5):
+  ts-node@9.1.1(typescript@5.8.2):
     dependencies:
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
       source-map-support: 0.5.21
-      typescript: 5.4.5
+      typescript: 5.8.2
       yn: 3.1.1
 
   tslib@1.10.0: {}
@@ -7529,7 +7529,7 @@ snapshots:
 
   typescript-memoize@1.1.1: {}
 
-  typescript@5.4.5: {}
+  typescript@5.8.2: {}
 
   typical@4.0.0: {}
 


### PR DESCRIPTION
## What Changed

Remove typescript as a peer dependency, update dev typescript to 5.8.

Users will still need to provide typescript themselves, but any competent package manager will let the user know this.

## Checklist

Check the ones applicable to your change:

- [ ] Ran `pnpm run update-all`
- [ ] Tests are updated
- [ ] Documentation is updated

## Change Type

Indicate the type of change your pull request is:

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
